### PR TITLE
Improve project progress validation and persistence

### DIFF
--- a/PlanWriter.Application/Services/ProjectService.cs
+++ b/PlanWriter.Application/Services/ProjectService.cs
@@ -83,24 +83,40 @@ namespace PlanWriter.Application.Services
 
         public async Task AddProgressAsync(AddProjectProgressDto dto, ClaimsPrincipal user)
         {
+            if (dto is null)
+                throw new ArgumentNullException(nameof(dto));
+
+            if (dto.WordsWritten <= 0)
+                throw new ArgumentException("WordsWritten must be greater than zero.", nameof(dto));
+
             var userId = userService.GetUserId(user);
             var project = await projectRepo.GetUserProjectByIdAsync(dto.ProjectId, userId);
 
             if (project is null)
                 throw new KeyNotFoundException("Project not found");
 
+            var newTotalWords = project.CurrentWordCount + dto.WordsWritten;
+
             var progress = new ProjectProgress
             {
                 Id = Guid.NewGuid(),
                 ProjectId = project.Id,
                 WordsWritten = dto.WordsWritten,
-                Date = dto.Date,
+                TotalWordsWritten = newTotalWords,
+                RemainingWords = project.WordCountGoal.HasValue
+                    ? Math.Max(0, project.WordCountGoal.Value - newTotalWords)
+                    : 0,
+                RemainingPercentage = project.WordCountGoal.HasValue && project.WordCountGoal.Value > 0
+                    ? Math.Round((double)newTotalWords / project.WordCountGoal.Value * 100, 2)
+                    : 0,
+                Date = dto.Date == default ? DateTime.UtcNow : dto.Date,
                 Notes = dto.Notes
             };
 
-            project.CurrentWordCount += dto.WordsWritten;
+            project.CurrentWordCount = newTotalWords;
 
             await progressRepo.AddProgressAsync(progress);
+            await projectRepo.UpdateAsync(project);
         }
 
         public async Task<IEnumerable<ProgressHistoryDto>> GetProgressHistoryAsync(Guid projectId, ClaimsPrincipal user)

--- a/PlanWriter.Application/Validators/AddProjectProgressDtoValidator.cs
+++ b/PlanWriter.Application/Validators/AddProjectProgressDtoValidator.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
-using PlanWriter.Application.DTOs;
-using System;
 using PlanWriter.Application.DTO;
+using System;
 
 namespace PlanWriter.Application.Validators
 {
@@ -13,8 +12,8 @@ namespace PlanWriter.Application.Validators
                 .NotEmpty().WithMessage("Project ID is required.")
                 .NotEqual(Guid.Empty).WithMessage("Project ID cannot be empty GUID.");
 
-            // RuleFor(x => x.TotalWordsWritten)
-            //     .GreaterThanOrEqualTo(0).WithMessage("Total words written must be zero or greater.");
+            RuleFor(x => x.WordsWritten)
+                .GreaterThan(0).WithMessage("Words written must be greater than zero.");
         }
     }
 }

--- a/PlanWriter.Tests/Validators/AddProjectProgressDtoValidatorTests.cs
+++ b/PlanWriter.Tests/Validators/AddProjectProgressDtoValidatorTests.cs
@@ -1,61 +1,60 @@
 ﻿using FluentValidation.TestHelper;
-using PlanWriter.Application.DTOs;
+using PlanWriter.Application.DTO;
 using PlanWriter.Application.Validators;
 using System;
-using PlanWriter.Application.DTO;
 using Xunit;
 
 namespace PlanWriter.Application.Tests.Validators
 {
     public class AddProjectProgressDtoValidatorTests
     {
-        // private readonly AddProjectProgressDtoValidator _validator;
-        //
-        // public AddProjectProgressDtoValidatorTests()
-        // {
-        //     _validator = new AddProjectProgressDtoValidator();
-        // }
-        //
-        // [Fact]
-        // public void Should_Have_Error_When_ProjectId_Is_Empty()
-        // {
-        //     var dto = new AddProjectProgressDto
-        //     {
-        //         ProjectId = Guid.Empty,
-        //         TotalWordsWritten = 1000
-        //     };
-        //
-        //     var result = _validator.TestValidate(dto);
-        //
-        //     result.ShouldHaveValidationErrorFor(x => x.ProjectId);
-        // }
-        //
-        // [Fact]
-        // public void Should_Have_Error_When_TotalWordsWritten_Is_Negative()
-        // {
-        //     var dto = new AddProjectProgressDto
-        //     {
-        //         ProjectId = Guid.NewGuid(),
-        //         TotalWordsWritten = -50
-        //     };
-        //
-        //     var result = _validator.TestValidate(dto);
-        //
-        //     result.ShouldHaveValidationErrorFor(x => x.TotalWordsWritten);
-        // }
-        //
-        // [Fact]
-        // public void Should_Pass_When_Data_Is_Valid()
-        // {
-        //     var dto = new AddProjectProgressDto
-        //     {
-        //         ProjectId = Guid.NewGuid(),
-        //         TotalWordsWritten = 1500
-        //     };
-        //
-        //     var result = _validator.TestValidate(dto);
-        //
-        //     result.ShouldNotHaveAnyValidationErrors();
-        // }
+        private readonly AddProjectProgressDtoValidator _validator;
+
+        public AddProjectProgressDtoValidatorTests()
+        {
+            _validator = new AddProjectProgressDtoValidator();
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_ProjectId_Is_Empty()
+        {
+            var dto = new AddProjectProgressDto
+            {
+                ProjectId = Guid.Empty,
+                WordsWritten = 1000
+            };
+
+            var result = _validator.TestValidate(dto);
+
+            result.ShouldHaveValidationErrorFor(x => x.ProjectId);
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_WordsWritten_Is_Not_Positive()
+        {
+            var dto = new AddProjectProgressDto
+            {
+                ProjectId = Guid.NewGuid(),
+                WordsWritten = 0
+            };
+
+            var result = _validator.TestValidate(dto);
+
+            result.ShouldHaveValidationErrorFor(x => x.WordsWritten);
+        }
+
+        [Fact]
+        public void Should_Pass_When_Data_Is_Valid()
+        {
+            var dto = new AddProjectProgressDto
+            {
+                ProjectId = Guid.NewGuid(),
+                WordsWritten = 1500
+            };
+
+            var result = _validator.TestValidate(dto);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure progress entries require a valid DTO and positive word counts before persisting
- update project totals and derived metrics when adding progress entries
- reinstate validator unit tests to cover the new validation rules

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e903886828833280b3db555aa2fa3a