### PR TITLE
Fix swagger generation for project creation

### DIFF
--- a/PlanWriter.Application/Interfaces/IProjectService.cs
+++ b/PlanWriter.Application/Interfaces/IProjectService.cs
@@ -4,7 +4,6 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using PlanWriter.Domain.Dtos;
-using PlanWriter.Domain.Entities;
 using PlanWriter.Domain.Enums;
 
 
@@ -12,7 +11,7 @@ namespace PlanWriter.Application.Interfaces
 {
     public interface IProjectService
     {
-        Task<Project> CreateProjectAsync(CreateProjectDto dto, ClaimsPrincipal user);
+        Task<ProjectDto> CreateProjectAsync(CreateProjectDto dto, ClaimsPrincipal user);
         Task<IEnumerable<ProjectDto>> GetUserProjectsAsync(ClaimsPrincipal user);
         Task<ProjectDto> GetProjectByIdAsync(Guid id, ClaimsPrincipal user);
         Task AddProgressAsync(AddProjectProgressDto dto, ClaimsPrincipal user);

--- a/PlanWriter.Application/Services/ProjectService.cs
+++ b/PlanWriter.Application/Services/ProjectService.cs
@@ -28,7 +28,7 @@ public class ProjectService : IProjectService
         _userService = userService;
     }
 
-    public async Task<Project> CreateProjectAsync(CreateProjectDto dto, ClaimsPrincipal user)
+    public async Task<ProjectDto> CreateProjectAsync(CreateProjectDto dto, ClaimsPrincipal user)
     {
         var project = new Project
         {
@@ -46,7 +46,7 @@ public class ProjectService : IProjectService
         };
 
         await _projectRepository.CreateAsync(project);
-        return project;
+        return MapToDto(project);
     }
 
     public async Task<IEnumerable<ProjectDto>> GetUserProjectsAsync(ClaimsPrincipal user)


### PR DESCRIPTION
## Summary
- return a `ProjectDto` from `CreateProjectAsync` so the create endpoint no longer exposes the entity with circular navigation
- update the project service interface accordingly

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e9114e06e4833284341a683c0d2040