### PR TITLE
feat(wordwar): hardening de concorrência e auditoria (#26)

### DIFF
--- a/PlanWriter.Application/WordWar/Commands/CreateWordWarCommandHandler.cs
+++ b/PlanWriter.Application/WordWar/Commands/CreateWordWarCommandHandler.cs
@@ -58,7 +58,7 @@ public class CreateWordWarCommandHandler(ILogger<CreateWordWarCommandHandler> lo
         var startsAtUtc = now;
         var endsAtUtc = startsAtUtc.AddMinutes(request.DurationMinutes);
 
-        return await wordWarRepository.CreateAsync(
+        var warId = await wordWarRepository.CreateAsync(
             request.EventId,
             request.RequestedByUserId,
             request.DurationMinutes,
@@ -66,5 +66,14 @@ public class CreateWordWarCommandHandler(ILogger<CreateWordWarCommandHandler> lo
             endsAtUtc,
             WordWarStatus.Waiting,
             cancellationToken);
+
+        logger.LogInformation(
+            "Word war created in Waiting status. WarId: {WarId}, EventId: {EventId}, RequestedByUserId: {RequestedByUserId}, DurationMinutes: {DurationMinutes}",
+            warId,
+            request.EventId,
+            request.RequestedByUserId,
+            request.DurationMinutes);
+
+        return warId;
     }
 }

--- a/PlanWriter.Application/WordWar/Queries/GetWordWarScoreboardQueryHandler.cs
+++ b/PlanWriter.Application/WordWar/Queries/GetWordWarScoreboardQueryHandler.cs
@@ -36,6 +36,10 @@ public class GetWordWarScoreboardQueryHandler(ILogger<GetWordWarScoreboardQueryH
                 await wordWarRepository.PersistFinalRankAsync(request.WarId, cancellationToken);
                 wordWar.Status = WordWarStatus.Finished;
                 wordWar.FinishedAtUtc = now;
+                logger.LogInformation(
+                    "Word war auto-finished by scoreboard read. WarId: {WarId}, FinishedAtUtc: {FinishedAtUtc}",
+                    request.WarId,
+                    now);
             }
             else
             {
@@ -46,6 +50,11 @@ public class GetWordWarScoreboardQueryHandler(ILogger<GetWordWarScoreboardQueryH
                     logger.LogError("Word war not found after auto-finish attempt.");
                     throw new NotFoundException("Word war not found.");
                 }
+
+                logger.LogInformation(
+                    "Word war finish was already processed concurrently before scoreboard read completed. WarId: {WarId}, Status: {Status}",
+                    request.WarId,
+                    wordWar.Status);
             }
         }
 


### PR DESCRIPTION
## Resumo\n- hardening de concorrência para start/join/checkpoint/finish\n- idempotência em cenários de corrida\n- logs de auditoria em mudanças de estado\n- ajustes de auto-finish e scoreboard\n- ampliação dos testes de Word War\n\n## Testes\n- dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --filter "FullyQualifiedName~WordWar"\n\nCloses #26