### PR TITLE
feat(winner): centralize goodies API and eligibility (#19)

### DIFF
--- a/PlanWriter.API/Common/Middleware/ExceptionHandlingMiddleware.cs
+++ b/PlanWriter.API/Common/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
+using PlanWriter.Application.Common.Exceptions;
 
 namespace PlanWriter.API.Common.Middleware;
 
@@ -22,6 +23,22 @@ public class ExceptionHandlingMiddleware
         try
         {
             await _next(context);
+        }
+        catch (BusinessRuleException ex)
+        {
+            await WriteProblemAsync(
+                context,
+                HttpStatusCode.BadRequest,
+                ex.Message
+            );
+        }
+        catch (NotFoundException ex)
+        {
+            await WriteProblemAsync(
+                context,
+                HttpStatusCode.NotFound,
+                ex.Message
+            );
         }
         catch (InvalidOperationException ex)
         {

--- a/PlanWriter.API/Controllers/EventGoodiesController.cs
+++ b/PlanWriter.API/Controllers/EventGoodiesController.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PlanWriter.Application.Goodies.Dtos.Queries;
+using PlanWriter.Application.Interfaces;
+
+namespace PlanWriter.API.Controllers;
+
+[ApiController]
+[Route("api/events")]
+[Authorize]
+public sealed class EventGoodiesController(IMediator mediator, IUserService userService) : ControllerBase
+{
+    [HttpGet("{eventId:guid}/projects/{projectId:guid}/goodies")]
+    public async Task<IActionResult> GetEventGoodies(Guid eventId, Guid projectId)
+    {
+        var userId = userService.GetUserId(User);
+        var response = await mediator.Send(new GetEventGoodiesQuery(userId, eventId, projectId));
+        return Ok(response);
+    }
+}

--- a/PlanWriter.API/Program.cs
+++ b/PlanWriter.API/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Models;
 using PlanWriter.API.Common.Middleware;
 using PlanWriter.API.Middleware;
 using PlanWriter.Application;
+using PlanWriter.Application.Common.WinnerEligibility;
 using PlanWriter.Application.Interfaces;
 using PlanWriter.Application.Services;
 using PlanWriter.Application.Validators;
@@ -150,6 +151,7 @@ builder.Services.AddScoped<IUserRegistrationRepository, UserRegistrationReposito
 builder.Services.AddScoped<ICertificateReadRepository, CertificateReadRepository>();
 builder.Services.AddScoped<IDailyWordLogReadRepository, DailyWordLogReadRepository>();
 builder.Services.AddScoped<IProjectEventsReadRepository, ProjectEventsReadRepository>();
+builder.Services.AddScoped<IWinnerEligibilityService, WinnerEligibilityService>();
 
 builder.Services.AddScoped<IWordWarParticipantReadRepository, WordWarParticipantReadRepository>();
 builder.Services.AddScoped<IWordWarRepository, WordWarRepository>();

--- a/PlanWriter.Application/Common/WinnerEligibility/IWinnerEligibilityService.cs
+++ b/PlanWriter.Application/Common/WinnerEligibility/IWinnerEligibilityService.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PlanWriter.Application.Common.WinnerEligibility;
+
+public interface IWinnerEligibilityService
+{
+    WinnerEligibilityResult EvaluateForGoodies(
+        DateTime nowUtc,
+        DateTime eventEndsAtUtc,
+        int targetWords,
+        int totalWordsInEvent,
+        bool isValidated,
+        bool won);
+
+    WinnerEligibilityResult EvaluateForCertificate(bool isValidated, bool won);
+}

--- a/PlanWriter.Application/Common/WinnerEligibility/WinnerEligibilityResult.cs
+++ b/PlanWriter.Application/Common/WinnerEligibility/WinnerEligibilityResult.cs
@@ -1,0 +1,8 @@
+namespace PlanWriter.Application.Common.WinnerEligibility;
+
+public sealed record WinnerEligibilityResult(
+    bool IsEligible,
+    bool CanValidate,
+    string Status,
+    string Message
+);

--- a/PlanWriter.Application/Common/WinnerEligibility/WinnerEligibilityService.cs
+++ b/PlanWriter.Application/Common/WinnerEligibility/WinnerEligibilityService.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace PlanWriter.Application.Common.WinnerEligibility;
+
+public sealed class WinnerEligibilityService : IWinnerEligibilityService
+{
+    public WinnerEligibilityResult EvaluateForGoodies(
+        DateTime nowUtc,
+        DateTime eventEndsAtUtc,
+        int targetWords,
+        int totalWordsInEvent,
+        bool isValidated,
+        bool won)
+    {
+        if (targetWords <= 0)
+        {
+            return new WinnerEligibilityResult(
+                IsEligible: false,
+                CanValidate: false,
+                Status: "invalid_target",
+                Message: "A meta do evento não está configurada corretamente."
+            );
+        }
+
+        if (isValidated && won)
+        {
+            return new WinnerEligibilityResult(
+                IsEligible: true,
+                CanValidate: false,
+                Status: "eligible",
+                Message: "Parabéns! Você liberou os goodies de vencedor."
+            );
+        }
+
+        if (totalWordsInEvent >= targetWords)
+        {
+            return new WinnerEligibilityResult(
+                IsEligible: false,
+                CanValidate: true,
+                Status: "pending_validation",
+                Message: "Meta atingida. Faça a validação final para liberar os goodies."
+            );
+        }
+
+        if (nowUtc < eventEndsAtUtc)
+        {
+            return new WinnerEligibilityResult(
+                IsEligible: false,
+                CanValidate: false,
+                Status: "in_progress",
+                Message: "Continue escrevendo para atingir a meta do evento."
+            );
+        }
+
+        return new WinnerEligibilityResult(
+            IsEligible: false,
+            CanValidate: false,
+            Status: "not_eligible",
+            Message: "Meta não atingida dentro do período do evento."
+        );
+    }
+
+    public WinnerEligibilityResult EvaluateForCertificate(bool isValidated, bool won)
+    {
+        if (isValidated && won)
+        {
+            return new WinnerEligibilityResult(
+                IsEligible: true,
+                CanValidate: false,
+                Status: "eligible",
+                Message: "Certificado liberado."
+            );
+        }
+
+        return new WinnerEligibilityResult(
+            IsEligible: false,
+            CanValidate: false,
+            Status: "not_eligible",
+            Message: "O certificado é liberado apenas para participantes vencedores com validação final."
+        );
+    }
+}

--- a/PlanWriter.Application/Goodies/Dtos/Queries/GetEventGoodiesQuery.cs
+++ b/PlanWriter.Application/Goodies/Dtos/Queries/GetEventGoodiesQuery.cs
@@ -1,0 +1,8 @@
+using System;
+using MediatR;
+using PlanWriter.Domain.Dtos.Goodies;
+
+namespace PlanWriter.Application.Goodies.Dtos.Queries;
+
+public sealed record GetEventGoodiesQuery(Guid UserId, Guid EventId, Guid ProjectId)
+    : IRequest<EventGoodiesDto>;

--- a/PlanWriter.Application/Goodies/Queries/GetEventGoodiesQueryHandler.cs
+++ b/PlanWriter.Application/Goodies/Queries/GetEventGoodiesQueryHandler.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Common.WinnerEligibility;
+using PlanWriter.Application.Goodies.Dtos.Queries;
+using PlanWriter.Domain.Dtos.Badges;
+using PlanWriter.Domain.Dtos.Goodies;
+using PlanWriter.Domain.Interfaces.ReadModels.Badges;
+using PlanWriter.Domain.Interfaces.ReadModels.ProjectEvents;
+using PlanWriter.Domain.Interfaces.ReadModels.Projects;
+using IEventReadRepository = PlanWriter.Domain.Interfaces.ReadModels.Events.IEventReadRepository;
+
+namespace PlanWriter.Application.Goodies.Queries;
+
+public sealed class GetEventGoodiesQueryHandler(
+    ILogger<GetEventGoodiesQueryHandler> logger,
+    IEventReadRepository eventReadRepository,
+    IProjectReadRepository projectReadRepository,
+    IProjectEventsReadRepository projectEventsReadRepository,
+    IProjectProgressReadRepository projectProgressReadRepository,
+    IBadgeReadRepository badgeReadRepository,
+    IWinnerEligibilityService winnerEligibilityService)
+    : IRequestHandler<GetEventGoodiesQuery, EventGoodiesDto>
+{
+    public async Task<EventGoodiesDto> Handle(GetEventGoodiesQuery request, CancellationToken cancellationToken)
+    {
+        var eventEntity = await eventReadRepository.GetEventByIdAsync(request.EventId, cancellationToken)
+                          ?? throw new NotFoundException("Evento não encontrado.");
+
+        var project = await projectReadRepository.GetUserProjectByIdAsync(
+                          request.ProjectId,
+                          request.UserId,
+                          cancellationToken)
+                      ?? throw new NotFoundException("Projeto não encontrado.");
+
+        var projectEvent = await projectEventsReadRepository.GetByProjectAndEventWithEventAsync(
+                               request.ProjectId,
+                               request.EventId,
+                               cancellationToken)
+                           ?? throw new NotFoundException("Projeto não está inscrito neste evento.");
+
+        var targetWords = projectEvent.TargetWords ?? eventEntity.DefaultTargetWords ?? 50000;
+        var totalWords = await GetTotalWordsInEventWindowAsync(
+            request.ProjectId,
+            request.UserId,
+            eventEntity.StartsAtUtc,
+            eventEntity.EndsAtUtc,
+            cancellationToken);
+
+        var persistedTotal = projectEvent.ValidatedWords ?? projectEvent.FinalWordCount ?? 0;
+        var effectiveTotalWords = Math.Max(totalWords, persistedTotal);
+
+        var eligibility = winnerEligibilityService.EvaluateForGoodies(
+            DateTime.UtcNow,
+            eventEntity.EndsAtUtc,
+            targetWords,
+            effectiveTotalWords,
+            projectEvent.ValidatedAtUtc.HasValue,
+            projectEvent.Won);
+
+        var badges = await badgeReadRepository.GetByProjectIdAsync(request.ProjectId, request.UserId, cancellationToken);
+        var eventBadges = badges
+            .Where(x => x.EventId == request.EventId)
+            .Select(x => new BadgeDto
+            {
+                Id = x.Id,
+                ProjectId = x.ProjectId,
+                EventId = x.EventId,
+                Name = x.Name,
+                Description = x.Description,
+                Icon = x.Icon,
+                AwardedAt = x.AwardedAt
+            })
+            .ToList();
+
+        logger.LogInformation(
+            "Goodies loaded for Event {EventId}, Project {ProjectId}, User {UserId}. Eligible={Eligible}, Status={Status}",
+            request.EventId,
+            request.ProjectId,
+            request.UserId,
+            eligibility.IsEligible,
+            eligibility.Status);
+
+        return new EventGoodiesDto
+        {
+            EventId = request.EventId,
+            ProjectId = request.ProjectId,
+            EventName = eventEntity.Name,
+            ProjectTitle = project.Title ?? "Projeto",
+            TargetWords = targetWords,
+            TotalWords = effectiveTotalWords,
+            ValidatedAtUtc = projectEvent.ValidatedAtUtc,
+            Won = projectEvent.Won,
+            Eligibility = new WinnerEligibilityDto
+            {
+                IsEligible = eligibility.IsEligible,
+                CanValidate = eligibility.CanValidate,
+                Status = eligibility.Status,
+                Message = eligibility.Message
+            },
+            Certificate = new CertificateGoodieDto
+            {
+                Available = eligibility.IsEligible,
+                DownloadUrl = eligibility.IsEligible
+                    ? $"/api/events/{request.EventId}/projects/{request.ProjectId}/certificate"
+                    : null,
+                Message = eligibility.IsEligible
+                    ? "Certificado disponível para download."
+                    : eligibility.CanValidate
+                        ? "Faça a validação final para liberar o certificado."
+                        : eligibility.Message
+            },
+            Badges = eventBadges
+        };
+    }
+
+    private async Task<int> GetTotalWordsInEventWindowAsync(
+        Guid projectId,
+        Guid userId,
+        DateTime startsAtUtc,
+        DateTime endsAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var progress = await projectProgressReadRepository.GetProgressByProjectIdAsync(projectId, userId, cancellationToken);
+        return progress
+            .Where(x => x.CreatedAt >= startsAtUtc && x.CreatedAt < endsAtUtc)
+            .Sum(x => (int?)x.WordsWritten) ?? 0;
+    }
+}

--- a/PlanWriter.Domain/Dtos/Goodies/EventGoodiesDto.cs
+++ b/PlanWriter.Domain/Dtos/Goodies/EventGoodiesDto.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using PlanWriter.Domain.Dtos.Badges;
+
+namespace PlanWriter.Domain.Dtos.Goodies;
+
+public sealed class EventGoodiesDto
+{
+    public Guid EventId { get; set; }
+    public Guid ProjectId { get; set; }
+    public string EventName { get; set; } = string.Empty;
+    public string ProjectTitle { get; set; } = string.Empty;
+    public int TargetWords { get; set; }
+    public int TotalWords { get; set; }
+    public DateTime? ValidatedAtUtc { get; set; }
+    public bool Won { get; set; }
+    public WinnerEligibilityDto Eligibility { get; set; } = new();
+    public CertificateGoodieDto Certificate { get; set; } = new();
+    public IReadOnlyList<BadgeDto> Badges { get; set; } = Array.Empty<BadgeDto>();
+}
+
+public sealed class WinnerEligibilityDto
+{
+    public bool IsEligible { get; set; }
+    public bool CanValidate { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+}
+
+public sealed class CertificateGoodieDto
+{
+    public bool Available { get; set; }
+    public string? DownloadUrl { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/PlanWriter.Tests/Common/WinnerEligibility/WinnerEligibilityServiceTests.cs
+++ b/PlanWriter.Tests/Common/WinnerEligibility/WinnerEligibilityServiceTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using PlanWriter.Application.Common.WinnerEligibility;
+using Xunit;
+
+namespace PlanWriter.Tests.Common.WinnerEligibility;
+
+public class WinnerEligibilityServiceTests
+{
+    private readonly WinnerEligibilityService _sut = new();
+
+    [Fact]
+    public void EvaluateForGoodies_ShouldReturnEligible_WhenValidatedWinner()
+    {
+        var now = new DateTime(2026, 2, 1, 12, 0, 0, DateTimeKind.Utc);
+        var end = now.AddDays(1);
+
+        var result = _sut.EvaluateForGoodies(now, end, 50000, 50000, true, true);
+
+        result.IsEligible.Should().BeTrue();
+        result.Status.Should().Be("eligible");
+    }
+
+    [Fact]
+    public void EvaluateForGoodies_ShouldReturnPendingValidation_WhenTargetReachedButNotValidated()
+    {
+        var now = new DateTime(2026, 2, 1, 12, 0, 0, DateTimeKind.Utc);
+        var end = now.AddDays(1);
+
+        var result = _sut.EvaluateForGoodies(now, end, 50000, 50000, false, false);
+
+        result.IsEligible.Should().BeFalse();
+        result.CanValidate.Should().BeTrue();
+        result.Status.Should().Be("pending_validation");
+    }
+
+    [Fact]
+    public void EvaluateForGoodies_ShouldReturnInProgress_WhenEventStillOpenAndTargetNotReached()
+    {
+        var now = new DateTime(2026, 2, 1, 12, 0, 0, DateTimeKind.Utc);
+        var end = now.AddDays(1);
+
+        var result = _sut.EvaluateForGoodies(now, end, 50000, 12000, false, false);
+
+        result.Status.Should().Be("in_progress");
+        result.CanValidate.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateForGoodies_ShouldReturnNotEligible_WhenEventEndedAndTargetNotReached()
+    {
+        var now = new DateTime(2026, 2, 2, 12, 0, 0, DateTimeKind.Utc);
+        var end = now.AddDays(-1);
+
+        var result = _sut.EvaluateForGoodies(now, end, 50000, 12000, false, false);
+
+        result.Status.Should().Be("not_eligible");
+        result.IsEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateForCertificate_ShouldReturnNotEligible_WhenNotWinnerOrNotValidated()
+    {
+        var result = _sut.EvaluateForCertificate(false, true);
+
+        result.IsEligible.Should().BeFalse();
+        result.Status.Should().Be("not_eligible");
+    }
+}

--- a/PlanWriter.Tests/Goodies/Queries/GetEventGoodiesQueryHandlerTests.cs
+++ b/PlanWriter.Tests/Goodies/Queries/GetEventGoodiesQueryHandlerTests.cs
@@ -1,0 +1,255 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Common.WinnerEligibility;
+using PlanWriter.Application.Goodies.Dtos.Queries;
+using PlanWriter.Application.Goodies.Queries;
+using PlanWriter.Domain.Dtos.Events;
+using PlanWriter.Domain.Entities;
+using PlanWriter.Domain.Events;
+using PlanWriter.Domain.Interfaces.ReadModels.Badges;
+using PlanWriter.Domain.Interfaces.ReadModels.ProjectEvents;
+using PlanWriter.Domain.Interfaces.ReadModels.Projects;
+using IEventReadRepository = PlanWriter.Domain.Interfaces.ReadModels.Events.IEventReadRepository;
+using Xunit;
+
+namespace PlanWriter.Tests.Goodies.Queries;
+
+public class GetEventGoodiesQueryHandlerTests
+{
+    private readonly Mock<ILogger<GetEventGoodiesQueryHandler>> _loggerMock = new();
+    private readonly Mock<IEventReadRepository> _eventReadRepositoryMock = new();
+    private readonly Mock<IProjectReadRepository> _projectReadRepositoryMock = new();
+    private readonly Mock<IProjectEventsReadRepository> _projectEventsReadRepositoryMock = new();
+    private readonly Mock<IProjectProgressReadRepository> _projectProgressReadRepositoryMock = new();
+    private readonly Mock<IBadgeReadRepository> _badgeReadRepositoryMock = new();
+    private readonly Mock<IWinnerEligibilityService> _winnerEligibilityServiceMock = new();
+
+    [Fact]
+    public async Task Handle_ShouldThrowNotFound_WhenEventDoesNotExist()
+    {
+        var query = new GetEventGoodiesQuery(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EventDto?)null);
+
+        var sut = CreateHandler();
+        var act = async () => await sut.Handle(query, CancellationToken.None);
+
+        await act.Should()
+            .ThrowAsync<NotFoundException>()
+            .WithMessage("Evento não encontrado.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrowNotFound_WhenProjectDoesNotBelongToUser()
+    {
+        var query = new GetEventGoodiesQuery(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                query.EventId,
+                "NaNoWriMo",
+                "nanowrimo",
+                "Nanowrimo",
+                DateTime.UtcNow.AddDays(-10),
+                DateTime.UtcNow.AddDays(10),
+                50000,
+                true));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Project?)null);
+
+        var sut = CreateHandler();
+        var act = async () => await sut.Handle(query, CancellationToken.None);
+
+        await act.Should()
+            .ThrowAsync<NotFoundException>()
+            .WithMessage("Projeto não encontrado.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAggregatedGoodies_WhenDataIsValid()
+    {
+        var now = DateTime.UtcNow;
+        var query = new GetEventGoodiesQuery(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                query.EventId,
+                "Evento de Fevereiro",
+                "fev-2026",
+                "Nanowrimo",
+                now.AddDays(-30),
+                now.AddDays(2),
+                50000,
+                true));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project
+            {
+                Id = query.ProjectId,
+                Title = "Meu Romance"
+            });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(query.ProjectId, query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProjectEvent
+            {
+                ProjectId = query.ProjectId,
+                EventId = query.EventId,
+                TargetWords = 50000,
+                Won = true,
+                ValidatedAtUtc = now,
+                FinalWordCount = 52000
+            });
+
+        _projectProgressReadRepositoryMock
+            .Setup(x => x.GetProgressByProjectIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ProjectProgress { ProjectId = query.ProjectId, CreatedAt = now.AddDays(-3), WordsWritten = 1000 },
+                new ProjectProgress { ProjectId = query.ProjectId, CreatedAt = now.AddDays(-2), WordsWritten = 900 }
+            });
+
+        _winnerEligibilityServiceMock
+            .Setup(x => x.EvaluateForGoodies(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                50000,
+                52000,
+                true,
+                true))
+            .Returns(new WinnerEligibilityResult(
+                IsEligible: true,
+                CanValidate: false,
+                Status: "eligible",
+                Message: "Parabéns! Você liberou os goodies de vencedor."));
+
+        _badgeReadRepositoryMock
+            .Setup(x => x.GetByProjectIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new Badge
+                {
+                    Id = 1,
+                    Name = "Winner",
+                    Description = "Evento concluído",
+                    Icon = "🏆",
+                    ProjectId = query.ProjectId,
+                    EventId = query.EventId,
+                    AwardedAt = now
+                },
+                new Badge
+                {
+                    Id = 2,
+                    Name = "First Steps",
+                    Description = "Badge geral",
+                    Icon = "✨",
+                    ProjectId = query.ProjectId,
+                    EventId = null,
+                    AwardedAt = now
+                }
+            });
+
+        var sut = CreateHandler();
+        var result = await sut.Handle(query, CancellationToken.None);
+
+        result.EventId.Should().Be(query.EventId);
+        result.ProjectId.Should().Be(query.ProjectId);
+        result.ProjectTitle.Should().Be("Meu Romance");
+        result.TotalWords.Should().Be(52000);
+        result.Eligibility.IsEligible.Should().BeTrue();
+        result.Certificate.Available.Should().BeTrue();
+        result.Certificate.DownloadUrl.Should().Be($"/api/events/{query.EventId}/projects/{query.ProjectId}/certificate");
+        result.Badges.Should().HaveCount(1);
+        result.Badges[0].Name.Should().Be("Winner");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnPendingValidation_WhenTargetReachedWithoutValidation()
+    {
+        var now = DateTime.UtcNow;
+        var query = new GetEventGoodiesQuery(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                query.EventId,
+                "Evento",
+                "evento",
+                "Nanowrimo",
+                now.AddDays(-20),
+                now.AddDays(3),
+                50000,
+                true));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project { Id = query.ProjectId, Title = "Projeto X" });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(query.ProjectId, query.EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProjectEvent
+            {
+                ProjectId = query.ProjectId,
+                EventId = query.EventId,
+                TargetWords = 50000,
+                Won = false,
+                ValidatedAtUtc = null,
+                FinalWordCount = null
+            });
+
+        _projectProgressReadRepositoryMock
+            .Setup(x => x.GetProgressByProjectIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ProjectProgress { ProjectId = query.ProjectId, CreatedAt = now.AddDays(-2), WordsWritten = 30000 },
+                new ProjectProgress { ProjectId = query.ProjectId, CreatedAt = now.AddDays(-1), WordsWritten = 20000 }
+            });
+
+        _winnerEligibilityServiceMock
+            .Setup(x => x.EvaluateForGoodies(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                50000,
+                50000,
+                false,
+                false))
+            .Returns(new WinnerEligibilityResult(
+                IsEligible: false,
+                CanValidate: true,
+                Status: "pending_validation",
+                Message: "Meta atingida. Faça a validação final para liberar os goodies."));
+
+        _badgeReadRepositoryMock
+            .Setup(x => x.GetByProjectIdAsync(query.ProjectId, query.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Badge>());
+
+        var sut = CreateHandler();
+        var result = await sut.Handle(query, CancellationToken.None);
+
+        result.Eligibility.CanValidate.Should().BeTrue();
+        result.Certificate.Available.Should().BeFalse();
+        result.Certificate.Message.Should().Be("Faça a validação final para liberar o certificado.");
+    }
+
+    private GetEventGoodiesQueryHandler CreateHandler()
+    {
+        return new GetEventGoodiesQueryHandler(
+            _loggerMock.Object,
+            _eventReadRepositoryMock.Object,
+            _projectReadRepositoryMock.Object,
+            _projectEventsReadRepositoryMock.Object,
+            _projectProgressReadRepositoryMock.Object,
+            _badgeReadRepositoryMock.Object,
+            _winnerEligibilityServiceMock.Object);
+    }
+}


### PR DESCRIPTION
## Summary
- add unified goodies endpoint for event/project: GET /api/events/{eventId}/projects/{projectId}/goodies
- centralize winner eligibility rules in IWinnerEligibilityService
- reuse centralized rule in certificate generation flow
- improve business/not-found error handling in API middleware

## Tests
- GetEventGoodiesQueryHandlerTests
- WinnerEligibilityServiceTests
- updated GetCertificateQueryHandlerTests

Closes #19