### PR TITLE
feat(events): unify progress calculation across my/progress/leaderboard (#18)

### DIFF
--- a/PlanWriter.API/Program.cs
+++ b/PlanWriter.API/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Models;
 using PlanWriter.API.Common.Middleware;
 using PlanWriter.API.Middleware;
 using PlanWriter.Application;
+using PlanWriter.Application.Common.Events;
 using PlanWriter.Application.Common.WinnerEligibility;
 using PlanWriter.Application.Interfaces;
 using PlanWriter.Application.Services;
@@ -152,6 +153,7 @@ builder.Services.AddScoped<ICertificateReadRepository, CertificateReadRepository
 builder.Services.AddScoped<IDailyWordLogReadRepository, DailyWordLogReadRepository>();
 builder.Services.AddScoped<IProjectEventsReadRepository, ProjectEventsReadRepository>();
 builder.Services.AddScoped<IWinnerEligibilityService, WinnerEligibilityService>();
+builder.Services.AddScoped<IEventProgressCalculator, EventProgressCalculator>();
 
 builder.Services.AddScoped<IWordWarParticipantReadRepository, WordWarParticipantReadRepository>();
 builder.Services.AddScoped<IWordWarRepository, WordWarRepository>();

--- a/PlanWriter.Application/Common/Events/EventProgressCalculator.cs
+++ b/PlanWriter.Application/Common/Events/EventProgressCalculator.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace PlanWriter.Application.Common.Events;
+
+public sealed class EventProgressCalculator : IEventProgressCalculator
+{
+    private const int DefaultTargetWords = 50000;
+
+    public EventProgressMetrics Calculate(int? targetWords, int? totalWrittenInEvent)
+    {
+        var resolvedTarget = ResolveTarget(targetWords);
+        var normalizedTotal = Math.Max(0, totalWrittenInEvent.GetValueOrDefault());
+
+        var percent = (int)Math.Round(
+            normalizedTotal * 100m / resolvedTarget,
+            MidpointRounding.AwayFromZero);
+
+        var remaining = Math.Max(0, resolvedTarget - normalizedTotal);
+
+        return new EventProgressMetrics(
+            TargetWords: resolvedTarget,
+            TotalWords: normalizedTotal,
+            Percent: percent,
+            RemainingWords: remaining,
+            Won: normalizedTotal >= resolvedTarget
+        );
+    }
+
+    public DateTime ResolveWindowEndExclusive(DateTime endsAtUtc)
+        => endsAtUtc.Date.AddDays(1);
+
+    private static int ResolveTarget(int? targetWords)
+    {
+        var target = targetWords.GetValueOrDefault();
+        return target > 0 ? target : DefaultTargetWords;
+    }
+}

--- a/PlanWriter.Application/Common/Events/EventProgressMetrics.cs
+++ b/PlanWriter.Application/Common/Events/EventProgressMetrics.cs
@@ -1,0 +1,9 @@
+namespace PlanWriter.Application.Common.Events;
+
+public sealed record EventProgressMetrics(
+    int TargetWords,
+    int TotalWords,
+    int Percent,
+    int RemainingWords,
+    bool Won
+);

--- a/PlanWriter.Application/Common/Events/IEventProgressCalculator.cs
+++ b/PlanWriter.Application/Common/Events/IEventProgressCalculator.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace PlanWriter.Application.Common.Events;
+
+public interface IEventProgressCalculator
+{
+    EventProgressMetrics Calculate(int? targetWords, int? totalWrittenInEvent);
+    DateTime ResolveWindowEndExclusive(DateTime endsAtUtc);
+}

--- a/PlanWriter.Domain/Dtos/Events/EventLeaderboardRowDto.cs
+++ b/PlanWriter.Domain/Dtos/Events/EventLeaderboardRowDto.cs
@@ -1,6 +1,7 @@
 // Application/Events/Dtos/EventLeaderboardRowDto.cs
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace PlanWriter.Domain.Dtos.Events
 {
@@ -10,6 +11,8 @@ namespace PlanWriter.Domain.Dtos.Events
         public string ProjectTitle { get; set; } = "";
         public string UserName { get; set; } = "";
         public int Words { get; set; }
+        [JsonIgnore]
+        public int? TargetWords { get; set; }
         public double? Percent { get; set; } // 0..100 relativo à meta do projeto no evento
         public bool Won { get; set; }
         public int Rank { get; set; }

--- a/PlanWriter.Domain/Dtos/Events/MyEventDto.cs
+++ b/PlanWriter.Domain/Dtos/Events/MyEventDto.cs
@@ -14,4 +14,5 @@ public class MyEventDto
     public int? TotalWrittenInEvent { get; set; }
 
     public int Percent { get; set; }
+    public bool Won { get; set; }
 }

--- a/PlanWriter.Infrastructure/Repositories/EventRepository.cs
+++ b/PlanWriter.Infrastructure/Repositories/EventRepository.cs
@@ -225,17 +225,7 @@ public class EventRepository(IDbExecutor db) : IEventRepository
                 p.Title AS ProjectTitle,
                 (u.FirstName + ' ' + u.LastName) AS UserName,
                 COALESCE(agg.Words, 0) AS Words,
-                CASE
-                    WHEN COALESCE(pe.TargetWords, e.DefaultTargetWords, 50000) > 0
-                        THEN CAST(COALESCE(agg.Words, 0) * 100.0 / COALESCE(pe.TargetWords, e.DefaultTargetWords, 50000) AS float)
-                    ELSE 0
-                END AS Percent,
-                CASE
-                    WHEN COALESCE(pe.TargetWords, e.DefaultTargetWords, 50000) > 0
-                         AND COALESCE(agg.Words, 0) >= COALESCE(pe.TargetWords, e.DefaultTargetWords, 50000)
-                        THEN CAST(1 AS bit)
-                    ELSE CAST(0 AS bit)
-                END AS Won
+                COALESCE(pe.TargetWords, e.DefaultTargetWords, 50000) AS TargetWords
             FROM ProjectEvents pe
             INNER JOIN Projects p ON p.Id = pe.ProjectId
             INNER JOIN Users u ON u.Id = p.UserId

--- a/PlanWriter.Tests/Events/Common/EventProgressCalculatorTests.cs
+++ b/PlanWriter.Tests/Events/Common/EventProgressCalculatorTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using PlanWriter.Application.Common.Events;
+using Xunit;
+
+namespace PlanWriter.Tests.Events.Common;
+
+public class EventProgressCalculatorTests
+{
+    private readonly EventProgressCalculator _sut = new();
+
+    [Fact]
+    public void Calculate_ShouldUseProvidedTarget_WhenTargetIsPositive()
+    {
+        var result = _sut.Calculate(1000, 400);
+
+        result.TargetWords.Should().Be(1000);
+        result.TotalWords.Should().Be(400);
+        result.Percent.Should().Be(40);
+        result.RemainingWords.Should().Be(600);
+        result.Won.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Calculate_ShouldFallbackToDefaultTarget_WhenTargetIsNullOrZero()
+    {
+        var resultFromNull = _sut.Calculate(null, 500);
+        var resultFromZero = _sut.Calculate(0, 500);
+
+        resultFromNull.TargetWords.Should().Be(50000);
+        resultFromZero.TargetWords.Should().Be(50000);
+        resultFromNull.Percent.Should().Be(1);
+        resultFromZero.Percent.Should().Be(1);
+    }
+
+    [Fact]
+    public void Calculate_ShouldMarkWon_WhenTotalReachesTarget()
+    {
+        var result = _sut.Calculate(1000, 1200);
+
+        result.Won.Should().BeTrue();
+        result.RemainingWords.Should().Be(0);
+        result.Percent.Should().Be(120);
+    }
+
+    [Fact]
+    public void ResolveWindowEndExclusive_ShouldNormalizeToNextDay()
+    {
+        var endAt = new DateTime(2026, 2, 20, 11, 45, 0, DateTimeKind.Utc);
+
+        var endExclusive = _sut.ResolveWindowEndExclusive(endAt);
+
+        endExclusive.Should().Be(new DateTime(2026, 2, 21, 0, 0, 0, DateTimeKind.Utc));
+    }
+}

--- a/PlanWriter.Tests/Events/Queries/GetEventLeaderboardQueryHandlerTests.cs
+++ b/PlanWriter.Tests/Events/Queries/GetEventLeaderboardQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using PlanWriter.Application.Common.Events;
 using PlanWriter.Application.Events.Dtos.Queries;
 using PlanWriter.Application.Events.Queries;
 using PlanWriter.Domain.Dtos.Events;
@@ -14,9 +15,10 @@ public class GetEventLeaderboardQueryHandlerTests
 {
     private readonly Mock<IEventRepository> _eventRepositoryMock = new();
     private readonly Mock<ILogger<GetEventLeaderboardQueryHandler>> _loggerMock = new();
+    private readonly IEventProgressCalculator _eventProgressCalculator = new EventProgressCalculator();
 
     private GetEventLeaderboardQueryHandler CreateHandler()
-        => new(_eventRepositoryMock.Object, _loggerMock.Object);
+        => new(_eventRepositoryMock.Object, _eventProgressCalculator, _loggerMock.Object);
 
     [Fact]
     public async Task Handle_ShouldReturnLeaderboard_ForGlobalScope()
@@ -34,8 +36,8 @@ public class GetEventLeaderboardQueryHandlerTests
 
         var leaderboardRows = new List<EventLeaderboardRowDto>
         {
-            new() { ProjectTitle = "A", Words = 2000 },
-            new() { ProjectTitle = "B", Words = 3000 }
+            new() { ProjectTitle = "A", Words = 2000, TargetWords = 50000 },
+            new() { ProjectTitle = "B", Words = 3000, TargetWords = 50000 }
         };
 
         _eventRepositoryMock
@@ -61,6 +63,8 @@ public class GetEventLeaderboardQueryHandlerTests
         result[0].Rank.Should().Be(1);
         result[1].Rank.Should().Be(2);
         result[0].Words.Should().Be(3000);
+        result[0].Percent.Should().Be(6);
+        result[0].Won.Should().BeFalse();
     }
 
     [Fact]

--- a/PlanWriter.Tests/Events/Queries/GetEventProgressQueryHandlerTests.cs
+++ b/PlanWriter.Tests/Events/Queries/GetEventProgressQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using PlanWriter.Application.Common.Events;
 using PlanWriter.Application.Events.Dtos.Queries;
 using PlanWriter.Application.Events.Queries;
 using PlanWriter.Domain.Entities;
@@ -12,10 +13,10 @@ namespace PlanWriter.Tests.Events.Queries;
 
 public class GetEventProgressQueryHandlerTests
 {
-    private readonly Mock<IProjectEventsRepository> _projectEventsRepoMock = new();
     private readonly Mock<IProjectProgressRepository> _projectProgressRepoMock = new();
     private readonly Mock<ILogger<GetEventProgressQueryHandler>> _loggerMock = new();
     private readonly Mock<IProjectEventsReadRepository> _projectProgressReadRepoMock = new();
+    private readonly IEventProgressCalculator _eventProgressCalculator = new EventProgressCalculator();
     
 
     [Fact]
@@ -66,22 +67,24 @@ public class GetEventProgressQueryHandlerTests
             .ReturnsAsync(entries);
 
         var handler = new GetEventProgressQueryHandler(
-            _projectEventsRepoMock.Object,
             _projectProgressRepoMock.Object,
             _loggerMock.Object,
-            _projectProgressReadRepoMock.Object
+            _projectProgressReadRepoMock.Object,
+            _eventProgressCalculator
         );
 
-        var query = new GetEventProgressQuery(projectId, eventId);
+        var query = new GetEventProgressQuery(eventId, projectId);
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
 
         // Assert
         result.Should().NotBeNull();
-        //result!.TotalWords.Should().Be(3000);
+        result.TotalWrittenInEvent.Should().Be(3000);
+        result.Percent.Should().Be(6);
+        result.Won.Should().BeFalse();
         result.TargetWords.Should().Be(50000);
-        //result.EventName.Should().Be("NaNoWriMo");
+        result.Name.Should().Be("NaNoWriMo");
     }
 
     [Fact]
@@ -96,13 +99,13 @@ public class GetEventProgressQueryHandlerTests
             .ReturnsAsync((PlanWriter.Domain.Events.ProjectEvent?)null);
 
         var handler = new GetEventProgressQueryHandler(
-            _projectEventsRepoMock.Object,
             _projectProgressRepoMock.Object,
             _loggerMock.Object,
-            _projectProgressReadRepoMock.Object
+            _projectProgressReadRepoMock.Object,
+            _eventProgressCalculator
         );
 
-        var query = new GetEventProgressQuery(projectId, eventId);
+        var query = new GetEventProgressQuery(eventId, projectId);
 
         // Act
         Func<Task> act = async () => await handler.Handle(query, CancellationToken.None);
@@ -111,5 +114,57 @@ public class GetEventProgressQueryHandlerTests
         await act.Should()
             .ThrowAsync<KeyNotFoundException>()
             .WithMessage("Inscrição do projeto no evento não encontrada.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCalculateWon_WhenTotalIsGreaterThanOrEqualToTarget()
+    {
+        var projectId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        var ev = new PlanWriter.Domain.Events.Event
+        {
+            Id = eventId,
+            Name = "Sprint Event",
+            StartsAtUtc = now.AddDays(-5),
+            EndsAtUtc = now.AddDays(5),
+            DefaultTargetWords = 1000
+        };
+
+        var projectEvent = new PlanWriter.Domain.Events.ProjectEvent
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            EventId = eventId,
+            TargetWords = 1000,
+            Event = ev,
+            Won = false
+        };
+
+        _projectProgressReadRepoMock
+            .Setup(r => r.GetByProjectAndEventWithEventAsync(projectId, eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectEvent);
+
+        _projectProgressRepoMock
+            .Setup(r => r.GetByProjectAndDateRangeAsync(projectId, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ProjectProgress { ProjectId = projectId, WordsWritten = 1200, CreatedAt = now.AddDays(-1) }
+            });
+
+        var handler = new GetEventProgressQueryHandler(
+            _projectProgressRepoMock.Object,
+            _loggerMock.Object,
+            _projectProgressReadRepoMock.Object,
+            _eventProgressCalculator
+        );
+
+        var result = await handler.Handle(new GetEventProgressQuery(eventId, projectId), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Won.Should().BeTrue();
+        result.Percent.Should().Be(120);
+        result.Remaining.Should().Be(0);
     }
 }


### PR DESCRIPTION
## Summary
- add centralized progress calculator for target/total/percent/won
- reuse same rule in events/my, event progress endpoint and leaderboard
- normalize target fallback to 50000 when target is null/zero
- keep leaderboard payload stable while computing won/percent in backend service

## Tests
- EventProgressCalculatorTests
- GetMyEventsQueryHandlerTests
- GetEventProgressQueryHandlerTests
- GetEventLeaderboardQueryHandlerTests
- EventRepositoryTests

Closes #18