### PR TITLE
[Auth][BE] Strong password policy for register/change-password

### DIFF
--- a/PlanWriter.Application/Auth/Commands/RegisterUserCommandHandler.cs
+++ b/PlanWriter.Application/Auth/Commands/RegisterUserCommandHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using PlanWriter.Application.Auth.Dtos.Commands;
+using PlanWriter.Application.Security;
 using PlanWriter.Domain.Entities;
 using PlanWriter.Domain.Interfaces.Auth.Regsitration;
 
@@ -23,6 +24,13 @@ public class RegisterUserCommandHandler(IUserRegistrationReadRepository readRepo
             logger.LogWarning("Register failed: email {Email} already exists", email);
 
             throw new InvalidOperationException($"Register failed: email {email} already exists");
+        }
+
+        var passwordValidationError = PasswordPolicy.Validate(request.Request.Password);
+        if (passwordValidationError is not null)
+        {
+            logger.LogWarning("Register failed: weak password for {Email}. Reason: {ValidationError}", email, passwordValidationError);
+            throw new InvalidOperationException(passwordValidationError);
         }
 
         var user = MapRequestToUser(request, email);

--- a/PlanWriter.Application/Security/PasswordPolicy.cs
+++ b/PlanWriter.Application/Security/PasswordPolicy.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlanWriter.Application.Security;
+
+public static class PasswordPolicy
+{
+    public const int MinimumLength = 12;
+
+    private static readonly HashSet<string> BlockedPasswords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "admin",
+        "admin123",
+        "password",
+        "password123",
+        "password123!",
+        "123456",
+        "12345678",
+        "123456789",
+        "1234567890",
+        "qwerty",
+        "letmein",
+        "senha",
+        "senha123",
+        "planwriter"
+    };
+
+    public static string? Validate(string? password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return "Senha é obrigatória.";
+        }
+
+        var value = password.Trim();
+
+        if (value.Length < MinimumLength)
+        {
+            return $"A senha deve ter pelo menos {MinimumLength} caracteres.";
+        }
+
+        if (!value.Any(char.IsUpper))
+        {
+            return "A senha deve conter ao menos uma letra maiúscula.";
+        }
+
+        if (!value.Any(char.IsLower))
+        {
+            return "A senha deve conter ao menos uma letra minúscula.";
+        }
+
+        if (!value.Any(char.IsDigit))
+        {
+            return "A senha deve conter ao menos um número.";
+        }
+
+        if (!value.Any(ch => char.IsPunctuation(ch) || char.IsSymbol(ch)))
+        {
+            return "A senha deve conter ao menos um símbolo.";
+        }
+
+        if (BlockedPasswords.Contains(value))
+        {
+            return "Esta senha é muito comum. Escolha uma senha mais forte.";
+        }
+
+        return null;
+    }
+}

--- a/PlanWriter.Application/Validators/ChangePasswordDtoValidator.cs
+++ b/PlanWriter.Application/Validators/ChangePasswordDtoValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using PlanWriter.Application.Security;
+using PlanWriter.Domain.Dtos.Auth;
+
+namespace PlanWriter.Application.Validators;
+
+public class ChangePasswordDtoValidator : AbstractValidator<ChangePasswordDto>
+{
+    public ChangePasswordDtoValidator()
+    {
+        RuleFor(x => x.NewPassword)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Senha é obrigatória.")
+            .Must(password => PasswordPolicy.Validate(password) is null)
+            .WithMessage(dto => PasswordPolicy.Validate(dto.NewPassword)!);
+    }
+}

--- a/PlanWriter.Application/Validators/RegisterUserDtoValidator.cs
+++ b/PlanWriter.Application/Validators/RegisterUserDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentValidation;
 using PlanWriter.Application.DTO;
+using PlanWriter.Application.Security;
 
 namespace PlanWriter.Application.Validators;
 
@@ -21,8 +22,10 @@ public class RegisterUserDtoValidator : AbstractValidator<RegisterUserDto>
             .EmailAddress().WithMessage("Invalid email format.");
 
         RuleFor(x => x.Password)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(6).WithMessage("Password must be at least 6 characters.");
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Senha é obrigatória.")
+            .Must(password => PasswordPolicy.Validate(password) is null)
+            .WithMessage(dto => PasswordPolicy.Validate(dto.Password)!);
 
         RuleFor(x => x.DateOfBirth)
             .NotEmpty().WithMessage("Date of birth is required.")

--- a/PlanWriter.Tests/API/Integration/AuthApiTestCollection.cs
+++ b/PlanWriter.Tests/API/Integration/AuthApiTestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace PlanWriter.Tests.API.Integration;
+
+[CollectionDefinition(Name)]
+public sealed class AuthApiTestCollection : ICollectionFixture<AuthApiWebApplicationFactory>
+{
+    public const string Name = "Auth API Integration";
+}

--- a/PlanWriter.Tests/API/Integration/AuthControllerIntegrationTests.cs
+++ b/PlanWriter.Tests/API/Integration/AuthControllerIntegrationTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using PlanWriter.Application.DTO;
+using PlanWriter.Domain.Dtos.Auth;
+using PlanWriter.Domain.Entities;
+using Xunit;
+
+namespace PlanWriter.Tests.API.Integration;
+
+[Collection(AuthApiTestCollection.Name)]
+public sealed class AuthControllerIntegrationTests(AuthApiWebApplicationFactory factory)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Register_WithWeakPassword_ShouldReturnBadRequest()
+    {
+        factory.Store.Reset();
+        using var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", BuildRegisterDto("123456"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>(JsonOptions);
+        problem.Should().NotBeNull();
+        problem!.Errors.SelectMany(e => e.Value)
+            .Should().Contain(m => m.Contains("pelo menos 12 caracteres", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Register_WithCommonPassword_ShouldReturnBadRequest()
+    {
+        factory.Store.Reset();
+        using var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", BuildRegisterDto("Password123!"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>(JsonOptions);
+        problem.Should().NotBeNull();
+        problem!.Errors.SelectMany(e => e.Value)
+            .Should().Contain(m => m.Contains("muito comum", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Register_WithStrongPassword_ShouldCreateUser()
+    {
+        factory.Store.Reset();
+        using var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", BuildRegisterDto("StrongPassword#2026"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory.Store.SnapshotUsers().Should().ContainSingle(u => u.Email == "newuser@planwriter.com");
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWeakPassword_ShouldReturnBadRequest()
+    {
+        factory.Store.Reset();
+
+        var userId = Guid.NewGuid();
+        factory.Store.Seed(new User
+        {
+            Id = userId,
+            Email = "writer@planwriter.com",
+            PasswordHash = "old-hash",
+            DateOfBirth = new DateTime(1995, 1, 1)
+        });
+
+        using var client = CreateClient(userId);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordDto { NewPassword = "123456" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>(JsonOptions);
+        problem.Should().NotBeNull();
+        problem!.Errors.SelectMany(e => e.Value)
+            .Should().Contain(m => m.Contains("pelo menos 12 caracteres", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithStrongPassword_ShouldUpdatePassword()
+    {
+        factory.Store.Reset();
+
+        var userId = Guid.NewGuid();
+        factory.Store.Seed(new User
+        {
+            Id = userId,
+            Email = "writer@planwriter.com",
+            PasswordHash = "old-hash",
+            DateOfBirth = new DateTime(1995, 1, 1)
+        });
+
+        using var client = CreateClient(userId);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordDto { NewPassword = "StrongPassword#2026" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        var updatedUser = factory.Store.SnapshotUsers().Single(u => u.Id == userId);
+        updatedUser.PasswordHash.Should().NotBe("old-hash");
+        updatedUser.PasswordHash.Should().NotBe("StrongPassword#2026");
+    }
+
+    private static RegisterUserDto BuildRegisterDto(string password)
+    {
+        return new RegisterUserDto
+        {
+            FirstName = "Novo",
+            LastName = "Usuario",
+            Email = "newuser@planwriter.com",
+            Password = password,
+            DateOfBirth = new DateTime(1990, 1, 1)
+        };
+    }
+
+    private HttpClient CreateClient(Guid? authenticatedUserId = null)
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        if (authenticatedUserId.HasValue)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, authenticatedUserId.Value.ToString());
+        }
+
+        return client;
+    }
+}

--- a/PlanWriter.Tests/API/Integration/FakeJwtTokenGenerator.cs
+++ b/PlanWriter.Tests/API/Integration/FakeJwtTokenGenerator.cs
@@ -1,0 +1,12 @@
+using PlanWriter.Domain.Entities;
+using PlanWriter.Domain.Interfaces.Auth;
+
+namespace PlanWriter.Tests.API.Integration;
+
+public sealed class FakeJwtTokenGenerator : IJwtTokenGenerator
+{
+    public string Generate(User user)
+    {
+        return $"fake-jwt-{user.Id}";
+    }
+}

--- a/PlanWriter.Tests/API/Integration/InMemoryAuthRepository.cs
+++ b/PlanWriter.Tests/API/Integration/InMemoryAuthRepository.cs
@@ -1,0 +1,151 @@
+using PlanWriter.Domain.Entities;
+using PlanWriter.Domain.Interfaces.Auth.Regsitration;
+using PlanWriter.Domain.Interfaces.ReadModels.Auth;
+using PlanWriter.Domain.Interfaces.ReadModels.Users;
+using PlanWriter.Domain.Interfaces.Repositories;
+
+namespace PlanWriter.Tests.API.Integration;
+
+public sealed class InMemoryAuthRepository :
+    IUserReadRepository,
+    IUserRepository,
+    IUserRegistrationReadRepository,
+    IUserRegistrationRepository,
+    IUserPasswordRepository
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<Guid, User> _users = new();
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _users.Clear();
+        }
+    }
+
+    public void Seed(User user)
+    {
+        lock (_lock)
+        {
+            _users[user.Id] = user;
+        }
+    }
+
+    public IReadOnlyList<User> SnapshotUsers()
+    {
+        lock (_lock)
+        {
+            return _users.Values.ToList();
+        }
+    }
+
+    public Task<bool> EmailExistsAsync(string email, CancellationToken ct)
+    {
+        var normalizedEmail = Normalize(email);
+
+        lock (_lock)
+        {
+            return Task.FromResult(
+                _users.Values.Any(u => Normalize(u.Email) == normalizedEmail));
+        }
+    }
+
+    public Task<User?> GetByEmailAsync(string email, CancellationToken ct)
+    {
+        var normalizedEmail = Normalize(email);
+
+        lock (_lock)
+        {
+            var user = _users.Values.FirstOrDefault(u => Normalize(u.Email) == normalizedEmail);
+            return Task.FromResult(user);
+        }
+    }
+
+    public Task<User?> GetByIdAsync(Guid userId, CancellationToken ct)
+    {
+        lock (_lock)
+        {
+            _users.TryGetValue(userId, out var user);
+            return Task.FromResult(user);
+        }
+    }
+
+    public Task<bool> SlugExistsAsync(string slug, Guid userId, CancellationToken ct)
+    {
+        var normalizedSlug = slug?.Trim().ToLowerInvariant();
+
+        lock (_lock)
+        {
+            var exists = _users.Values.Any(u =>
+                u.Id != userId &&
+                !string.IsNullOrWhiteSpace(u.Slug) &&
+                u.Slug!.Trim().ToLowerInvariant() == normalizedSlug);
+
+            return Task.FromResult(exists);
+        }
+    }
+
+    public Task<User?> GetBySlugAsync(string slug, CancellationToken ct)
+    {
+        var normalizedSlug = slug?.Trim().ToLowerInvariant();
+
+        lock (_lock)
+        {
+            var user = _users.Values.FirstOrDefault(u =>
+                !string.IsNullOrWhiteSpace(u.Slug) &&
+                u.Slug!.Trim().ToLowerInvariant() == normalizedSlug);
+
+            return Task.FromResult(user);
+        }
+    }
+
+    public Task<IReadOnlyList<User>> GetUsersByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct)
+    {
+        var idSet = ids.ToHashSet();
+
+        lock (_lock)
+        {
+            var result = _users.Values.Where(u => idSet.Contains(u.Id)).ToList();
+            return Task.FromResult<IReadOnlyList<User>>(result);
+        }
+    }
+
+    public Task CreateAsync(User user, CancellationToken ct)
+    {
+        lock (_lock)
+        {
+            _users[user.Id] = user;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(User user, CancellationToken ct)
+    {
+        lock (_lock)
+        {
+            _users[user.Id] = user;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdatePasswordAsync(Guid userId, string passwordHash, CancellationToken ct)
+    {
+        lock (_lock)
+        {
+            if (_users.TryGetValue(userId, out var user))
+            {
+                user.PasswordHash = passwordHash;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string Normalize(string? value)
+    {
+        return (value ?? string.Empty).Trim().ToLowerInvariant();
+    }
+}

--- a/PlanWriter.Tests/Admin/Commands/ChangePasswordCommandHandlerTests.cs
+++ b/PlanWriter.Tests/Admin/Commands/ChangePasswordCommandHandlerTests.cs
@@ -26,7 +26,7 @@ public class ChangePasswordCommandHandlerTests
     {
         // Arrange
         var userId = Guid.NewGuid();
-        var newPassword = "NewStrongPassword!";
+        var newPassword = "NewStrongPassword1!";
         var hashed = "hashed-password";
         var token = "fake-jwt";
 
@@ -78,7 +78,7 @@ public class ChangePasswordCommandHandlerTests
 
 
     [Fact]
-    public async Task Handle_ShouldThrow_WhenPasswordIsTooShort()
+    public async Task Handle_ShouldThrow_WhenPasswordIsWeak()
     {
         var handler = CreateHandler();
         var command = BuildCommand(Guid.NewGuid(), "123");
@@ -88,7 +88,7 @@ public class ChangePasswordCommandHandlerTests
 
         await act.Should()
             .ThrowAsync<InvalidOperationException>()
-            .WithMessage("Password must have at least 6 characters.");
+            .WithMessage("A senha deve ter pelo menos 12 caracteres.");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class ChangePasswordCommandHandlerTests
             .ReturnsAsync((User?)null);
 
         var handler = CreateHandler();
-        var command = BuildCommand(userId, "Password123!");
+        var command = BuildCommand(userId, "ValidPassword#2026");
 
         Func<Task> act = async () =>
             await handler.Handle(command, CancellationToken.None);
@@ -116,7 +116,7 @@ public class ChangePasswordCommandHandlerTests
     {
         // Arrange
         var userId = Guid.NewGuid();
-        const string newPassword = "NewStrongPassword!";
+        const string newPassword = "NewStrongPassword1!";
         const string hashed = "hashed-password";
         const string token = "admin-jwt";
 

--- a/PlanWriter.Tests/Security/PasswordPolicyTests.cs
+++ b/PlanWriter.Tests/Security/PasswordPolicyTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using PlanWriter.Application.Security;
+using Xunit;
+
+namespace PlanWriter.Tests.Security;
+
+public class PasswordPolicyTests
+{
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordIsEmpty()
+    {
+        var result = PasswordPolicy.Validate(string.Empty);
+
+        result.Should().Be("Senha é obrigatória.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordIsShort()
+    {
+        var result = PasswordPolicy.Validate("Abc123!");
+
+        result.Should().Be("A senha deve ter pelo menos 12 caracteres.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordMissingUppercase()
+    {
+        var result = PasswordPolicy.Validate("validpassword#2026");
+
+        result.Should().Be("A senha deve conter ao menos uma letra maiúscula.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordMissingLowercase()
+    {
+        var result = PasswordPolicy.Validate("VALIDPASSWORD#2026");
+
+        result.Should().Be("A senha deve conter ao menos uma letra minúscula.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordMissingNumber()
+    {
+        var result = PasswordPolicy.Validate("ValidPassword#");
+
+        result.Should().Be("A senha deve conter ao menos um número.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordMissingSymbol()
+    {
+        var result = PasswordPolicy.Validate("ValidPassword2026");
+
+        result.Should().Be("A senha deve conter ao menos um símbolo.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPasswordIsBlocked()
+    {
+        var result = PasswordPolicy.Validate("Password123!");
+
+        result.Should().Be("Esta senha é muito comum. Escolha uma senha mais forte.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnNull_WhenPasswordIsValid()
+    {
+        var result = PasswordPolicy.Validate("ValidPassword#2026");
+
+        result.Should().BeNull();
+    }
+}

--- a/PlanWriter.Tests/Validators/ChangePasswordDtoValidatorTests.cs
+++ b/PlanWriter.Tests/Validators/ChangePasswordDtoValidatorTests.cs
@@ -1,0 +1,43 @@
+using FluentValidation.TestHelper;
+using PlanWriter.Application.Validators;
+using PlanWriter.Domain.Dtos.Auth;
+using Xunit;
+
+namespace PlanWriter.Tests.Validators;
+
+public class ChangePasswordDtoValidatorTests
+{
+    private readonly ChangePasswordDtoValidator _validator = new();
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Is_Empty()
+    {
+        var dto = new ChangePasswordDto { NewPassword = string.Empty };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.NewPassword)
+            .WithErrorMessage("Senha é obrigatória.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Is_Common()
+    {
+        var dto = new ChangePasswordDto { NewPassword = "Password123!" };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.NewPassword)
+            .WithErrorMessage("Esta senha é muito comum. Escolha uma senha mais forte.");
+    }
+
+    [Fact]
+    public void Should_Pass_When_Password_Is_Strong()
+    {
+        var dto = new ChangePasswordDto { NewPassword = "StrongPassword#2026" };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.NewPassword);
+    }
+}

--- a/PlanWriter.Tests/Validators/RegisterUserDtoValidatorTests.cs
+++ b/PlanWriter.Tests/Validators/RegisterUserDtoValidatorTests.cs
@@ -1,99 +1,93 @@
-﻿using FluentValidation.TestHelper;
+using System;
+using FluentValidation.TestHelper;
 using PlanWriter.Application.DTO;
 using PlanWriter.Application.Validators;
 using Xunit;
 
-namespace PlanWriter.Tests.Validators
+namespace PlanWriter.Tests.Validators;
+
+public class RegisterUserDtoValidatorTests
 {
-    public class RegisterUserDtoValidatorTests
+    private readonly RegisterUserDtoValidator _validator = new();
+
+    [Fact]
+    public void Should_Have_Error_When_Fields_Are_Empty()
     {
-        private readonly RegisterUserDtoValidator _validator;
+        var dto = new RegisterUserDto();
 
-        public RegisterUserDtoValidatorTests()
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+        result.ShouldHaveValidationErrorFor(x => x.DateOfBirth);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Invalid()
+    {
+        var dto = BuildValidDto();
+        dto.Email = "invalid-email";
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Is_Weak()
+    {
+        var dto = BuildValidDto();
+        dto.Password = "Abc123!";
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Is_Common()
+    {
+        var dto = BuildValidDto();
+        dto.Password = "Password123!";
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Password)
+            .WithErrorMessage("Esta senha é muito comum. Escolha uma senha mais forte.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_DateOfBirth_Is_In_The_Future()
+    {
+        var dto = BuildValidDto();
+        dto.DateOfBirth = DateTime.Now.AddDays(1);
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.DateOfBirth);
+    }
+
+    [Fact]
+    public void Should_Pass_When_All_Fields_Are_Valid()
+    {
+        var dto = BuildValidDto();
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static RegisterUserDto BuildValidDto()
+    {
+        return new RegisterUserDto
         {
-            _validator = new RegisterUserDtoValidator();
-        }
-
-        [Fact]
-        public void Should_Have_Error_When_Fields_Are_Empty()
-        {
-            var dto = new RegisterUserDto();
-
-            var result = _validator.TestValidate(dto);
-
-            result.ShouldHaveValidationErrorFor(x => x.FirstName);
-            result.ShouldHaveValidationErrorFor(x => x.LastName);
-            result.ShouldHaveValidationErrorFor(x => x.Email);
-            result.ShouldHaveValidationErrorFor(x => x.Password);
-            result.ShouldHaveValidationErrorFor(x => x.DateOfBirth);
-        }
-
-        [Fact]
-        public void Should_Have_Error_When_Email_Is_Invalid()
-        {
-            var dto = new RegisterUserDto
-            {
-                FirstName = "Test",
-                LastName = "User",
-                Email = "invalid-email",
-                Password = "123456",
-                DateOfBirth = DateTime.Now.AddYears(-20)
-            };
-
-            var result = _validator.TestValidate(dto);
-
-            result.ShouldHaveValidationErrorFor(x => x.Email);
-        }
-
-        [Fact]
-        public void Should_Have_Error_When_Password_Is_Too_Short()
-        {
-            var dto = new RegisterUserDto
-            {
-                FirstName = "Test",
-                LastName = "User",
-                Email = "test@example.com",
-                Password = "123",
-                DateOfBirth = DateTime.Now.AddYears(-20)
-            };
-
-            var result = _validator.TestValidate(dto);
-
-            result.ShouldHaveValidationErrorFor(x => x.Password);
-        }
-
-        [Fact]
-        public void Should_Have_Error_When_DateOfBirth_Is_In_The_Future()
-        {
-            var dto = new RegisterUserDto
-            {
-                FirstName = "Test",
-                LastName = "User",
-                Email = "test@example.com",
-                Password = "123456",
-                DateOfBirth = DateTime.Now.AddDays(1)
-            };
-
-            var result = _validator.TestValidate(dto);
-
-            result.ShouldHaveValidationErrorFor(x => x.DateOfBirth);
-        }
-
-        [Fact]
-        public void Should_Pass_When_All_Fields_Are_Valid()
-        {
-            var dto = new RegisterUserDto
-            {
-                FirstName = "Test",
-                LastName = "User",
-                Email = "test@example.com",
-                Password = "123456",
-                DateOfBirth = DateTime.Now.AddYears(-20)
-            };
-
-            var result = _validator.TestValidate(dto);
-
-            result.ShouldNotHaveAnyValidationErrors();
-        }
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com",
+            Password = "ValidPassword#2026",
+            DateOfBirth = DateTime.Now.AddYears(-20)
+        };
     }
 }


### PR DESCRIPTION
Objetivo
Aplicar politica forte de senha nos fluxos de registro e troca de senha.

Implementacao
- Criada regra centralizada PasswordPolicy
- Regras aplicadas: minimo 12 caracteres, ao menos 1 maiuscula, ao menos 1 minuscula, ao menos 1 numero, ao menos 1 simbolo
- Bloqueio de senhas comuns com lista minima
- Registro com validacao por FluentValidation e validacao defensiva no handler
- Troca de senha com novo ChangePasswordDtoValidator e validacao defensiva no handler
- Mensagens de validacao padronizadas e amigaveis

Testes
- Unitarios para PasswordPolicy, validadores e handlers
- Integracao para AuthController cobrindo senha fraca/comum com 400 e senha forte com sucesso

Resultado de execucao
dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --nologo --no-restore
414 aprovados e 0 falhas

Closes #51