### PR TITLE
[Auth][BE] Rate limit and progressive login lockout

### DIFF
--- a/PlanWriter.API/Security/ILoginLockoutService.cs
+++ b/PlanWriter.API/Security/ILoginLockoutService.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace PlanWriter.API.Security;
+
+public interface ILoginLockoutService
+{
+    LoginLockoutStatus Check(string email, string? ipAddress, DateTime utcNow);
+    LoginLockoutStatus RegisterFailure(string email, string? ipAddress, DateTime utcNow);
+    void RegisterSuccess(string email, string? ipAddress);
+}
+
+public sealed record LoginLockoutStatus(
+    bool IsLocked,
+    DateTime? LockedUntilUtc,
+    int UserFailureCount,
+    int IpFailureCount
+);

--- a/PlanWriter.API/Security/InMemoryLoginLockoutService.cs
+++ b/PlanWriter.API/Security/InMemoryLoginLockoutService.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace PlanWriter.API.Security;
+
+public sealed class InMemoryLoginLockoutService(LoginLockoutOptions? options = null) : ILoginLockoutService
+{
+    private readonly LoginLockoutOptions _options = options ?? new LoginLockoutOptions();
+    private readonly ConcurrentDictionary<string, CounterState> _states = new(StringComparer.OrdinalIgnoreCase);
+
+    public LoginLockoutStatus Check(string email, string? ipAddress, DateTime utcNow)
+    {
+        var userKey = BuildUserKey(email);
+        var ipKey = BuildIpKey(ipAddress);
+
+        var user = EvaluateState(userKey, _options.UserSteps, utcNow);
+        var ip = EvaluateState(ipKey, _options.IpSteps, utcNow);
+
+        return Merge(user, ip);
+    }
+
+    public LoginLockoutStatus RegisterFailure(string email, string? ipAddress, DateTime utcNow)
+    {
+        var userKey = BuildUserKey(email);
+        var ipKey = BuildIpKey(ipAddress);
+
+        var user = IncrementFailure(userKey, _options.UserSteps, utcNow);
+        var ip = IncrementFailure(ipKey, _options.IpSteps, utcNow);
+
+        return Merge(user, ip);
+    }
+
+    public void RegisterSuccess(string email, string? ipAddress)
+    {
+        var userKey = BuildUserKey(email);
+        _states.TryRemove(userKey, out _);
+
+        var ipKey = BuildIpKey(ipAddress);
+        if (ipKey is not null)
+        {
+            _states.TryRemove(ipKey, out _);
+        }
+    }
+
+    private CounterView EvaluateState(string? key, LockoutStep[] steps, DateTime utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return CounterView.Empty;
+        }
+
+        if (!_states.TryGetValue(key, out var state))
+        {
+            return CounterView.Empty;
+        }
+
+        lock (state.Sync)
+        {
+            if (state.LockedUntilUtc.HasValue && state.LockedUntilUtc.Value <= utcNow)
+            {
+                state.LockedUntilUtc = null;
+            }
+
+            if (state.LastFailureUtc.HasValue && utcNow - state.LastFailureUtc.Value > _options.FailureWindow)
+            {
+                _states.TryRemove(key, out _);
+                return CounterView.Empty;
+            }
+
+            var isLocked = state.LockedUntilUtc.HasValue && state.LockedUntilUtc.Value > utcNow;
+            return new CounterView(
+                isLocked,
+                state.LockedUntilUtc,
+                state.FailureCount
+            );
+        }
+    }
+
+    private CounterView IncrementFailure(string? key, LockoutStep[] steps, DateTime utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return CounterView.Empty;
+        }
+
+        var state = _states.GetOrAdd(key, _ => new CounterState());
+
+        lock (state.Sync)
+        {
+            if (state.LastFailureUtc.HasValue && utcNow - state.LastFailureUtc.Value > _options.FailureWindow)
+            {
+                state.FailureCount = 0;
+                state.LockedUntilUtc = null;
+            }
+
+            state.FailureCount++;
+            state.LastFailureUtc = utcNow;
+
+            var step = steps
+                .Where(s => state.FailureCount >= s.Failures)
+                .OrderBy(s => s.Failures)
+                .LastOrDefault();
+
+            if (step != default)
+            {
+                var until = utcNow.Add(step.Duration);
+                if (!state.LockedUntilUtc.HasValue || until > state.LockedUntilUtc.Value)
+                {
+                    state.LockedUntilUtc = until;
+                }
+            }
+
+            var isLocked = state.LockedUntilUtc.HasValue && state.LockedUntilUtc.Value > utcNow;
+            return new CounterView(
+                isLocked,
+                state.LockedUntilUtc,
+                state.FailureCount
+            );
+        }
+    }
+
+    private static LoginLockoutStatus Merge(CounterView user, CounterView ip)
+    {
+        var isLocked = user.IsLocked || ip.IsLocked;
+        var maxLockUntil = MaxDateTime(user.LockedUntilUtc, ip.LockedUntilUtc);
+
+        return new LoginLockoutStatus(
+            IsLocked: isLocked,
+            LockedUntilUtc: maxLockUntil,
+            UserFailureCount: user.FailureCount,
+            IpFailureCount: ip.FailureCount
+        );
+    }
+
+    private static string BuildUserKey(string email)
+    {
+        var normalized = (email ?? string.Empty).Trim().ToLowerInvariant();
+        return $"usr:{normalized}";
+    }
+
+    private static string? BuildIpKey(string? ipAddress)
+    {
+        var normalized = (ipAddress ?? string.Empty).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : $"ip:{normalized}";
+    }
+
+    private static DateTime? MaxDateTime(DateTime? left, DateTime? right)
+    {
+        if (!left.HasValue)
+        {
+            return right;
+        }
+
+        if (!right.HasValue)
+        {
+            return left;
+        }
+
+        return left.Value >= right.Value ? left : right;
+    }
+
+    private sealed class CounterState
+    {
+        public object Sync { get; } = new();
+        public int FailureCount { get; set; }
+        public DateTime? LastFailureUtc { get; set; }
+        public DateTime? LockedUntilUtc { get; set; }
+    }
+
+    private readonly record struct CounterView(bool IsLocked, DateTime? LockedUntilUtc, int FailureCount)
+    {
+        public static CounterView Empty => new(false, null, 0);
+    }
+}

--- a/PlanWriter.API/Security/LoginLockoutOptions.cs
+++ b/PlanWriter.API/Security/LoginLockoutOptions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace PlanWriter.API.Security;
+
+public sealed class LoginLockoutOptions
+{
+    public TimeSpan FailureWindow { get; init; } = TimeSpan.FromMinutes(30);
+
+    public LockoutStep[] UserSteps { get; init; } =
+    [
+        new(5, TimeSpan.FromMinutes(1)),
+        new(8, TimeSpan.FromMinutes(5)),
+        new(10, TimeSpan.FromMinutes(15))
+    ];
+
+    public LockoutStep[] IpSteps { get; init; } =
+    [
+        new(10, TimeSpan.FromMinutes(1)),
+        new(20, TimeSpan.FromMinutes(5)),
+        new(30, TimeSpan.FromMinutes(15))
+    ];
+}
+
+public readonly record struct LockoutStep(int Failures, TimeSpan Duration);

--- a/PlanWriter.Tests/API/Controllers/AuthControllerLockoutTests.cs
+++ b/PlanWriter.Tests/API/Controllers/AuthControllerLockoutTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using PlanWriter.API.Controllers;
+using PlanWriter.API.Security;
+using PlanWriter.Application.Auth.Dtos.Commands;
+using PlanWriter.Application.DTO;
+using Xunit;
+
+namespace PlanWriter.Tests.API.Controllers;
+
+public class AuthControllerLockoutTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<ILoginLockoutService> _lockoutService = new();
+    private readonly Mock<ILogger<AuthController>> _logger = new();
+    private readonly TimeProvider _timeProvider = new FixedTimeProvider(
+        new DateTimeOffset(2026, 2, 20, 19, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task Login_ShouldReturnForbidden_WhenPreCheckIsLocked()
+    {
+        var request = new LoginUserDto
+        {
+            Email = "user@planwriter.com",
+            Password = "Whatever123!"
+        };
+
+        _lockoutService
+            .Setup(s => s.Check("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(true, DateTime.UtcNow.AddMinutes(1), 5, 3));
+
+        var controller = CreateController("10.0.0.1");
+
+        var result = await controller.Login(request);
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnUnauthorized_WhenCredentialsAreInvalidAndNotLocked()
+    {
+        var request = new LoginUserDto
+        {
+            Email = "user@planwriter.com",
+            Password = "invalid-pass"
+        };
+
+        _lockoutService
+            .Setup(s => s.Check("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(false, null, 0, 0));
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<LoginUserCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _lockoutService
+            .Setup(s => s.RegisterFailure("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(false, null, 1, 1));
+
+        var controller = CreateController("10.0.0.1");
+
+        var result = await controller.Login(request);
+
+        result.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnForbidden_WhenFailureTriggersLockout()
+    {
+        var request = new LoginUserDto
+        {
+            Email = "user@planwriter.com",
+            Password = "invalid-pass"
+        };
+
+        _lockoutService
+            .Setup(s => s.Check("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(false, null, 4, 2));
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<LoginUserCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _lockoutService
+            .Setup(s => s.RegisterFailure("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(true, DateTime.UtcNow.AddMinutes(2), 5, 3));
+
+        var controller = CreateController("10.0.0.1");
+
+        var result = await controller.Login(request);
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnTokenAndResetCounters_WhenCredentialsAreValid()
+    {
+        var request = new LoginUserDto
+        {
+            Email = "user@planwriter.com",
+            Password = "ValidPassword#2026"
+        };
+
+        _lockoutService
+            .Setup(s => s.Check("user@planwriter.com", "10.0.0.1", It.IsAny<DateTime>()))
+            .Returns(new LoginLockoutStatus(false, null, 0, 0));
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<LoginUserCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("jwt-token");
+
+        var controller = CreateController("10.0.0.1");
+
+        var result = await controller.Login(request);
+
+        result.Should().BeOfType<OkObjectResult>();
+        _lockoutService.Verify(
+            s => s.RegisterSuccess("user@planwriter.com", "10.0.0.1"),
+            Times.Once);
+    }
+
+    private AuthController CreateController(string ipAddress)
+    {
+        var controller = new AuthController(
+            _mediator.Object,
+            _lockoutService.Object,
+            _timeProvider,
+            _logger.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        controller.HttpContext.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+        return controller;
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/PlanWriter.Tests/Security/InMemoryLoginLockoutServiceTests.cs
+++ b/PlanWriter.Tests/Security/InMemoryLoginLockoutServiceTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using PlanWriter.API.Security;
+using Xunit;
+
+namespace PlanWriter.Tests.Security;
+
+public class InMemoryLoginLockoutServiceTests
+{
+    [Fact]
+    public void RegisterFailure_ShouldLockUser_WhenThresholdIsReached()
+    {
+        var service = new InMemoryLoginLockoutService(new LoginLockoutOptions
+        {
+            UserSteps =
+            [
+                new LockoutStep(3, TimeSpan.FromMinutes(1))
+            ],
+            IpSteps =
+            [
+                new LockoutStep(100, TimeSpan.FromMinutes(1))
+            ]
+        });
+
+        var now = Utc(2026, 2, 20, 18, 0, 0);
+
+        service.RegisterFailure("user@planwriter.com", "10.0.0.10", now);
+        service.RegisterFailure("user@planwriter.com", "10.0.0.10", now.AddSeconds(1));
+        var status = service.RegisterFailure("user@planwriter.com", "10.0.0.10", now.AddSeconds(2));
+
+        status.IsLocked.Should().BeTrue();
+        status.UserFailureCount.Should().Be(3);
+        status.LockedUntilUtc.Should().Be(now.AddSeconds(2).AddMinutes(1));
+    }
+
+    [Fact]
+    public void Check_ShouldUnlock_WhenLockDurationExpires()
+    {
+        var service = new InMemoryLoginLockoutService(new LoginLockoutOptions
+        {
+            UserSteps =
+            [
+                new LockoutStep(2, TimeSpan.FromSeconds(30))
+            ],
+            IpSteps =
+            [
+                new LockoutStep(100, TimeSpan.FromMinutes(1))
+            ]
+        });
+
+        var now = Utc(2026, 2, 20, 18, 10, 0);
+
+        service.RegisterFailure("user@planwriter.com", "10.0.0.10", now);
+        service.RegisterFailure("user@planwriter.com", "10.0.0.10", now.AddSeconds(1));
+
+        var locked = service.Check("user@planwriter.com", "10.0.0.10", now.AddSeconds(10));
+        locked.IsLocked.Should().BeTrue();
+
+        var unlocked = service.Check("user@planwriter.com", "10.0.0.10", now.AddMinutes(1));
+        unlocked.IsLocked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RegisterFailure_ShouldUseIpFallback_WhenUsersChange()
+    {
+        var service = new InMemoryLoginLockoutService(new LoginLockoutOptions
+        {
+            UserSteps =
+            [
+                new LockoutStep(100, TimeSpan.FromMinutes(1))
+            ],
+            IpSteps =
+            [
+                new LockoutStep(4, TimeSpan.FromMinutes(2))
+            ]
+        });
+
+        var ip = "10.0.0.9";
+        var now = Utc(2026, 2, 20, 18, 20, 0);
+
+        service.RegisterFailure("a@planwriter.com", ip, now);
+        service.RegisterFailure("b@planwriter.com", ip, now.AddSeconds(1));
+        service.RegisterFailure("c@planwriter.com", ip, now.AddSeconds(2));
+        var status = service.RegisterFailure("d@planwriter.com", ip, now.AddSeconds(3));
+
+        status.IsLocked.Should().BeTrue();
+        status.IpFailureCount.Should().Be(4);
+        status.UserFailureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RegisterFailure_ShouldBeThreadSafe_UnderConcurrency()
+    {
+        var service = new InMemoryLoginLockoutService(new LoginLockoutOptions
+        {
+            UserSteps =
+            [
+                new LockoutStep(5, TimeSpan.FromMinutes(1))
+            ],
+            IpSteps =
+            [
+                new LockoutStep(100, TimeSpan.FromMinutes(1))
+            ]
+        });
+
+        var now = Utc(2026, 2, 20, 18, 30, 0);
+        var tasks = Enumerable
+            .Range(0, 50)
+            .Select(_ => Task.Run(() =>
+                service.RegisterFailure("parallel@planwriter.com", "10.0.0.88", now)))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var status = service.Check("parallel@planwriter.com", "10.0.0.88", now);
+        status.IsLocked.Should().BeTrue();
+        status.UserFailureCount.Should().Be(50);
+    }
+
+    private static DateTime Utc(int year, int month, int day, int hour, int minute, int second)
+    {
+        return new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
+    }
+}


### PR DESCRIPTION
Objetivo
Mitigar brute force em autenticacao com rate limit por endpoint e lockout progressivo por usuario com fallback por IP.

Implementacao
- Adicionado rate limit para /api/auth/login e /api/auth/register
- Adicionado servico InMemoryLoginLockoutService com:
  - contador de falhas por usuario
  - contador de falhas por IP (fallback)
  - janela de falhas configuravel
  - lockout progressivo por degraus
- Login agora verifica lockout antes de autenticar
- Falha de login incrementa contadores e ativa bloqueio temporario quando necessario
- Sucesso de login limpa estado de lockout
- Durante lockout, login retorna 403 com mensagem generica
- Tentativas bloqueadas sao registradas em log

Testes
- Unitarios do servico de lockout cobrindo:
  - lock por threshold
  - unlock apos expiracao
  - fallback por IP
  - concorrencia/thread safety
- Testes do AuthController cobrindo:
  - retorno 403 quando lockout ativo
  - retorno 401 em credencial invalida sem lock
  - ativacao de lockout apos falhas
  - reset de lockout em sucesso

Execucao
- dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --nologo --no-restore
- 422 aprovados, 0 falhas

Closes #52