### PR TITLE
[Auth][BE] MFA obrigatório para área admin

### DIFF
--- a/PlanWriter.API/Program.cs
+++ b/PlanWriter.API/Program.cs
@@ -228,6 +228,7 @@ builder.Services.AddScoped<IUserRegistrationReadRepository, UserRegistrationRead
 builder.Services.AddScoped<IUserRegistrationRepository, UserRegistrationRepository>();
 builder.Services.AddScoped<IAuthAuditRepository, AuthAuditRepository>();
 builder.Services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+builder.Services.AddScoped<IAdminMfaRepository, AdminMfaRepository>();
 builder.Services.AddScoped<ICertificateReadRepository, CertificateReadRepository>();
 builder.Services.AddScoped<IDailyWordLogReadRepository, DailyWordLogReadRepository>();
 builder.Services.AddScoped<IProjectEventsReadRepository, ProjectEventsReadRepository>();

--- a/PlanWriter.API/Security/AdminOnlyAttribute.cs
+++ b/PlanWriter.API/Security/AdminOnlyAttribute.cs
@@ -17,8 +17,10 @@ namespace PlanWriter.API.Security
 
             var isAdminClaim =
                 context.HttpContext.User.FindFirst("isAdmin")?.Value;
+            var adminMfaVerifiedClaim =
+                context.HttpContext.User.FindFirst("adminMfaVerified")?.Value;
 
-            if (isAdminClaim != "true")
+            if (isAdminClaim != "true" || adminMfaVerifiedClaim != "true")
             {
                 context.Result = new ForbidResult();
             }

--- a/PlanWriter.Application/Auth/Commands/ChangePasswordCommandHandler.cs
+++ b/PlanWriter.Application/Auth/Commands/ChangePasswordCommandHandler.cs
@@ -56,7 +56,8 @@ public class ChangePasswordCommandHandler(IUserReadRepository userReadRepository
             user.Id,
             revokedSessions);
         
-        return tokenGenerator.Generate(user);
+        var adminMfaVerified = !user.IsAdmin || user.AdminMfaEnabled;
+        return tokenGenerator.Generate(user, adminMfaVerified);
     }
    
 }

--- a/PlanWriter.Application/Auth/Commands/ConfirmAdminMfaEnrollmentCommandHandler.cs
+++ b/PlanWriter.Application/Auth/Commands/ConfirmAdminMfaEnrollmentCommandHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using PlanWriter.Application.Auth.Dtos.Commands;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Security;
+using PlanWriter.Domain.Dtos.Auth;
+using PlanWriter.Domain.Interfaces.ReadModels.Users;
+using PlanWriter.Domain.Interfaces.Repositories.Auth;
+
+namespace PlanWriter.Application.Auth.Commands;
+
+public sealed class ConfirmAdminMfaEnrollmentCommandHandler(
+    IUserReadRepository userReadRepository,
+    IAdminMfaRepository adminMfaRepository,
+    TimeProvider timeProvider)
+    : IRequestHandler<ConfirmAdminMfaEnrollmentCommand, AdminMfaBackupCodesDto>
+{
+    public async Task<AdminMfaBackupCodesDto> Handle(ConfirmAdminMfaEnrollmentCommand request, CancellationToken ct)
+    {
+        var user = await userReadRepository.GetByIdAsync(request.UserId, ct);
+        if (user is null)
+        {
+            throw new NotFoundException("Usuário não encontrado.");
+        }
+
+        if (!user.IsAdmin)
+        {
+            throw new BusinessRuleException("Somente administradores podem configurar MFA.");
+        }
+
+        if (user.AdminMfaEnabled)
+        {
+            throw new BusinessRuleException("MFA já está habilitado para este administrador.");
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AdminMfaPendingSecret))
+        {
+            throw new BusinessRuleException("Inicie o enrollment do MFA antes de confirmar.");
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var isCodeValid = AdminMfaSecurity.ValidateTotpCode(user.AdminMfaPendingSecret, request.Code, now);
+        if (!isCodeValid)
+        {
+            throw new BusinessRuleException("Código MFA inválido.");
+        }
+
+        await adminMfaRepository.EnableAsync(user.Id, user.AdminMfaPendingSecret, ct);
+
+        var backupCodes = AdminMfaSecurity.GenerateBackupCodes();
+        var hashes = backupCodes.Select(AdminMfaSecurity.HashBackupCode).ToArray();
+        await adminMfaRepository.ReplaceBackupCodesAsync(user.Id, hashes, ct);
+
+        return new AdminMfaBackupCodesDto
+        {
+            BackupCodes = backupCodes
+        };
+    }
+}

--- a/PlanWriter.Application/Auth/Commands/RefreshSessionCommandHandler.cs
+++ b/PlanWriter.Application/Auth/Commands/RefreshSessionCommandHandler.cs
@@ -120,7 +120,8 @@ public sealed class RefreshSessionCommandHandler(
             now,
             ct);
 
-        var accessToken = jwtTokenGenerator.Generate(user);
+        var adminMfaVerified = !user.IsAdmin || user.AdminMfaEnabled;
+        var accessToken = jwtTokenGenerator.Generate(user, adminMfaVerified);
         return new AuthTokensDto
         {
             AccessToken = accessToken,

--- a/PlanWriter.Application/Auth/Commands/StartAdminMfaEnrollmentCommandHandler.cs
+++ b/PlanWriter.Application/Auth/Commands/StartAdminMfaEnrollmentCommandHandler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Options;
+using PlanWriter.Application.Auth.Dtos.Commands;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Security;
+using PlanWriter.Domain.Configurations;
+using PlanWriter.Domain.Dtos.Auth;
+using PlanWriter.Domain.Interfaces.ReadModels.Users;
+using PlanWriter.Domain.Interfaces.Repositories.Auth;
+
+namespace PlanWriter.Application.Auth.Commands;
+
+public sealed class StartAdminMfaEnrollmentCommandHandler(
+    IUserReadRepository userReadRepository,
+    IAdminMfaRepository adminMfaRepository,
+    IOptions<JwtOptions> jwtOptions,
+    TimeProvider timeProvider)
+    : IRequestHandler<StartAdminMfaEnrollmentCommand, AdminMfaEnrollmentDto>
+{
+    public async Task<AdminMfaEnrollmentDto> Handle(StartAdminMfaEnrollmentCommand request, CancellationToken ct)
+    {
+        var user = await userReadRepository.GetByIdAsync(request.UserId, ct);
+        if (user is null)
+        {
+            throw new NotFoundException("Usuário não encontrado.");
+        }
+
+        if (!user.IsAdmin)
+        {
+            throw new BusinessRuleException("Somente administradores podem configurar MFA.");
+        }
+
+        if (user.AdminMfaEnabled)
+        {
+            throw new BusinessRuleException("MFA já está habilitado para este administrador.");
+        }
+
+        var secret = AdminMfaSecurity.GenerateSecretKey();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        await adminMfaRepository.SetPendingSecretAsync(user.Id, secret, now, ct);
+
+        var issuer = string.IsNullOrWhiteSpace(jwtOptions.Value.Issuer)
+            ? "PlanWriter"
+            : jwtOptions.Value.Issuer.Trim();
+
+        return new AdminMfaEnrollmentDto
+        {
+            SecretKey = secret,
+            OtpAuthUri = AdminMfaSecurity.BuildOtpAuthUri(issuer, user.Email, secret)
+        };
+    }
+}

--- a/PlanWriter.Application/Auth/Dtos/Commands/ConfirmAdminMfaEnrollmentCommand.cs
+++ b/PlanWriter.Application/Auth/Dtos/Commands/ConfirmAdminMfaEnrollmentCommand.cs
@@ -1,0 +1,7 @@
+using System;
+using MediatR;
+using PlanWriter.Domain.Dtos.Auth;
+
+namespace PlanWriter.Application.Auth.Dtos.Commands;
+
+public sealed record ConfirmAdminMfaEnrollmentCommand(Guid UserId, string Code) : IRequest<AdminMfaBackupCodesDto>;

--- a/PlanWriter.Application/Auth/Dtos/Commands/StartAdminMfaEnrollmentCommand.cs
+++ b/PlanWriter.Application/Auth/Dtos/Commands/StartAdminMfaEnrollmentCommand.cs
@@ -1,0 +1,7 @@
+using System;
+using MediatR;
+using PlanWriter.Domain.Dtos.Auth;
+
+namespace PlanWriter.Application.Auth.Dtos.Commands;
+
+public sealed record StartAdminMfaEnrollmentCommand(Guid UserId) : IRequest<AdminMfaEnrollmentDto>;

--- a/PlanWriter.Application/DTO/LoginUserDto.cs
+++ b/PlanWriter.Application/DTO/LoginUserDto.cs
@@ -4,4 +4,6 @@ public class LoginUserDto
 {
     public string Email { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
+    public string? MfaCode { get; set; }
+    public string? BackupCode { get; set; }
 }

--- a/PlanWriter.Application/Security/AdminMfaSecurity.cs
+++ b/PlanWriter.Application/Security/AdminMfaSecurity.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PlanWriter.Application.Security;
+
+public static class AdminMfaSecurity
+{
+    private const int TotpDigits = 6;
+    private const int TimeStepSeconds = 30;
+    private const int AllowedDriftWindows = 1;
+    private const string Base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    private const string BackupCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+    public static string GenerateSecretKey(int bytesLength = 20)
+    {
+        var bytes = RandomNumberGenerator.GetBytes(Math.Max(16, bytesLength));
+        return EncodeBase32(bytes);
+    }
+
+    public static string BuildOtpAuthUri(string issuer, string accountEmail, string secret)
+    {
+        var safeIssuer = string.IsNullOrWhiteSpace(issuer) ? "PlanWriter" : issuer.Trim();
+        var safeAccount = string.IsNullOrWhiteSpace(accountEmail) ? "admin" : accountEmail.Trim();
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"otpauth://totp/{Uri.EscapeDataString(safeIssuer)}:{Uri.EscapeDataString(safeAccount)}?secret={secret}&issuer={Uri.EscapeDataString(safeIssuer)}&algorithm=SHA1&digits={TotpDigits}&period={TimeStepSeconds}");
+    }
+
+    public static bool ValidateTotpCode(string secret, string code, DateTime utcNow)
+    {
+        var normalizedCode = NormalizeTotpCode(code);
+        if (normalizedCode is null)
+        {
+            return false;
+        }
+
+        var keyBytes = DecodeBase32(secret);
+        if (keyBytes.Length == 0)
+        {
+            return false;
+        }
+
+        var unixTime = (long)(utcNow - DateTime.UnixEpoch).TotalSeconds;
+        var counter = unixTime / TimeStepSeconds;
+
+        for (var drift = -AllowedDriftWindows; drift <= AllowedDriftWindows; drift++)
+        {
+            var candidate = GenerateTotpCode(keyBytes, counter + drift);
+            if (CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(candidate),
+                    Encoding.ASCII.GetBytes(normalizedCode)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static string GenerateCurrentTotpCode(string secret, DateTime utcNow)
+    {
+        var keyBytes = DecodeBase32(secret);
+        if (keyBytes.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var unixTime = (long)(utcNow - DateTime.UnixEpoch).TotalSeconds;
+        var counter = unixTime / TimeStepSeconds;
+        return GenerateTotpCode(keyBytes, counter);
+    }
+
+    public static IReadOnlyList<string> GenerateBackupCodes(int count = 8)
+    {
+        var safeCount = Math.Clamp(count, 5, 20);
+        var list = new List<string>(safeCount);
+
+        for (var i = 0; i < safeCount; i++)
+        {
+            list.Add($"{GenerateBackupCodeGroup(4)}-{GenerateBackupCodeGroup(4)}");
+        }
+
+        return list;
+    }
+
+    public static string NormalizeBackupCode(string backupCode)
+    {
+        if (string.IsNullOrWhiteSpace(backupCode))
+        {
+            return string.Empty;
+        }
+
+        var chars = backupCode
+            .Trim()
+            .ToUpperInvariant()
+            .Where(ch => char.IsLetterOrDigit(ch))
+            .ToArray();
+
+        return new string(chars);
+    }
+
+    public static string HashBackupCode(string backupCode)
+    {
+        var normalized = NormalizeBackupCode(backupCode);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return string.Empty;
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+        {
+            builder.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string? NormalizeTotpCode(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return null;
+        }
+
+        var normalized = new string(code.Trim().Where(char.IsDigit).ToArray());
+        return normalized.Length == TotpDigits ? normalized : null;
+    }
+
+    private static string GenerateBackupCodeGroup(int length)
+    {
+        var bytes = RandomNumberGenerator.GetBytes(length);
+        var chars = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            chars[i] = BackupCodeAlphabet[bytes[i] % BackupCodeAlphabet.Length];
+        }
+
+        return new string(chars);
+    }
+
+    private static string GenerateTotpCode(byte[] keyBytes, long counter)
+    {
+        Span<byte> counterBytes = stackalloc byte[8];
+        for (var i = 7; i >= 0; i--)
+        {
+            counterBytes[i] = (byte)(counter & 0xFF);
+            counter >>= 8;
+        }
+
+        using var hmac = new HMACSHA1(keyBytes);
+        var hash = hmac.ComputeHash(counterBytes.ToArray());
+        var offset = hash[^1] & 0x0F;
+        var binary =
+            ((hash[offset] & 0x7F) << 24) |
+            ((hash[offset + 1] & 0xFF) << 16) |
+            ((hash[offset + 2] & 0xFF) << 8) |
+            (hash[offset + 3] & 0xFF);
+
+        var otp = binary % (int)Math.Pow(10, TotpDigits);
+        return otp.ToString($"D{TotpDigits}", CultureInfo.InvariantCulture);
+    }
+
+    private static string EncodeBase32(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var outputLength = (int)Math.Ceiling(data.Length / 5d) * 8;
+        var output = new char[outputLength];
+
+        var buffer = (int)data[0];
+        var next = 1;
+        var bitsLeft = 8;
+        var index = 0;
+
+        while (index < outputLength)
+        {
+            if (bitsLeft < 5)
+            {
+                if (next < data.Length)
+                {
+                    buffer <<= 8;
+                    buffer |= data[next++] & 0xFF;
+                    bitsLeft += 8;
+                }
+                else
+                {
+                    var pad = 5 - bitsLeft;
+                    buffer <<= pad;
+                    bitsLeft += pad;
+                }
+            }
+
+            var value = (buffer >> (bitsLeft - 5)) & 0x1F;
+            bitsLeft -= 5;
+            output[index++] = Base32Alphabet[value];
+        }
+
+        return new string(output).TrimEnd('=');
+    }
+
+    private static byte[] DecodeBase32(string? base32)
+    {
+        if (string.IsNullOrWhiteSpace(base32))
+        {
+            return [];
+        }
+
+        var normalized = base32.Trim().TrimEnd('=').Replace(" ", string.Empty).ToUpperInvariant();
+        var byteCount = normalized.Length * 5 / 8;
+        var result = new byte[byteCount];
+
+        var buffer = 0;
+        var bitsLeft = 0;
+        var index = 0;
+
+        foreach (var ch in normalized)
+        {
+            var value = Base32Alphabet.IndexOf(ch);
+            if (value < 0)
+            {
+                return [];
+            }
+
+            buffer = (buffer << 5) | value;
+            bitsLeft += 5;
+
+            if (bitsLeft >= 8)
+            {
+                result[index++] = (byte)((buffer >> (bitsLeft - 8)) & 0xFF);
+                bitsLeft -= 8;
+            }
+        }
+
+        return result;
+    }
+}

--- a/PlanWriter.Domain/Dtos/Auth/AdminMfaBackupCodesDto.cs
+++ b/PlanWriter.Domain/Dtos/Auth/AdminMfaBackupCodesDto.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace PlanWriter.Domain.Dtos.Auth;
+
+public sealed class AdminMfaBackupCodesDto
+{
+    public IReadOnlyList<string> BackupCodes { get; init; } = [];
+}

--- a/PlanWriter.Domain/Dtos/Auth/AdminMfaConfirmDto.cs
+++ b/PlanWriter.Domain/Dtos/Auth/AdminMfaConfirmDto.cs
@@ -1,0 +1,6 @@
+namespace PlanWriter.Domain.Dtos.Auth;
+
+public sealed class AdminMfaConfirmDto
+{
+    public string Code { get; set; } = string.Empty;
+}

--- a/PlanWriter.Domain/Dtos/Auth/AdminMfaEnrollmentDto.cs
+++ b/PlanWriter.Domain/Dtos/Auth/AdminMfaEnrollmentDto.cs
@@ -1,0 +1,7 @@
+namespace PlanWriter.Domain.Dtos.Auth;
+
+public sealed class AdminMfaEnrollmentDto
+{
+    public string SecretKey { get; init; } = string.Empty;
+    public string OtpAuthUri { get; init; } = string.Empty;
+}

--- a/PlanWriter.Domain/Entities/User.cs
+++ b/PlanWriter.Domain/Entities/User.cs
@@ -20,6 +20,10 @@ namespace PlanWriter.Domain.Entities
 
         public bool IsAdmin { get; private set; }
         public bool MustChangePassword { get; private set; }
+        public bool AdminMfaEnabled { get; private set; }
+        public string? AdminMfaSecret { get; private set; }
+        public string? AdminMfaPendingSecret { get; private set; }
+        public DateTime? AdminMfaPendingGeneratedAtUtc { get; private set; }
 
         public void MakeAdmin()
         {
@@ -32,6 +36,10 @@ namespace PlanWriter.Domain.Entities
         {
             IsAdmin = false;
             MustChangePassword = false;
+            AdminMfaEnabled = false;
+            AdminMfaSecret = null;
+            AdminMfaPendingSecret = null;
+            AdminMfaPendingGeneratedAtUtc = null;
         }
 
         public void ChangePassword(string newHash)
@@ -41,6 +49,30 @@ namespace PlanWriter.Domain.Entities
            
             if (IsAdmin)
                 MustChangePassword = false;
+        }
+
+        public void SetAdminMfaPending(string secret, DateTime generatedAtUtc)
+        {
+            if (!IsAdmin)
+            {
+                throw new InvalidOperationException("Only admins can configure MFA.");
+            }
+
+            AdminMfaPendingSecret = secret;
+            AdminMfaPendingGeneratedAtUtc = generatedAtUtc;
+        }
+
+        public void EnableAdminMfa(string secret)
+        {
+            if (!IsAdmin)
+            {
+                throw new InvalidOperationException("Only admins can enable MFA.");
+            }
+
+            AdminMfaEnabled = true;
+            AdminMfaSecret = secret;
+            AdminMfaPendingSecret = null;
+            AdminMfaPendingGeneratedAtUtc = null;
         }
         
         

--- a/PlanWriter.Domain/Interfaces/Auth/IJwtTokenGenerator.cs
+++ b/PlanWriter.Domain/Interfaces/Auth/IJwtTokenGenerator.cs
@@ -4,5 +4,5 @@ namespace PlanWriter.Domain.Interfaces.Auth;
 
 public interface IJwtTokenGenerator
 {
-    string Generate(User user);
+    string Generate(User user, bool adminMfaVerified = false);
 }

--- a/PlanWriter.Domain/Interfaces/Repositories/Auth/IAdminMfaRepository.cs
+++ b/PlanWriter.Domain/Interfaces/Repositories/Auth/IAdminMfaRepository.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlanWriter.Domain.Interfaces.Repositories.Auth;
+
+public interface IAdminMfaRepository
+{
+    Task SetPendingSecretAsync(Guid userId, string pendingSecret, DateTime generatedAtUtc, CancellationToken ct);
+    Task EnableAsync(Guid userId, string activeSecret, CancellationToken ct);
+    Task ReplaceBackupCodesAsync(Guid userId, IReadOnlyCollection<string> codeHashes, CancellationToken ct);
+    Task<bool> ConsumeBackupCodeAsync(Guid userId, string codeHash, DateTime usedAtUtc, CancellationToken ct);
+}

--- a/PlanWriter.Infrastructure/Auth/JwtTokenGenerator.cs
+++ b/PlanWriter.Infrastructure/Auth/JwtTokenGenerator.cs
@@ -14,7 +14,7 @@ public class JwtTokenGenerator(
     IOptions<JwtOptions> jwtOptions,
     IOptions<AuthTokenOptions> tokenOptions) : IJwtTokenGenerator
 {
-    public string Generate(User user)
+    public string Generate(User user, bool adminMfaVerified = false)
     {
         var options = jwtOptions.Value;
         var now = DateTime.UtcNow;
@@ -31,6 +31,7 @@ public class JwtTokenGenerator(
             new(ClaimTypes.Email, user.Email),
             new(ClaimTypes.Name, user.FirstName),
             new("isAdmin", user.IsAdmin.ToString().ToLowerInvariant()),
+            new("adminMfaVerified", (!user.IsAdmin || adminMfaVerified).ToString().ToLowerInvariant()),
             new("mustChangePassword", user.MustChangePassword.ToString().ToLowerInvariant()),
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
             new(JwtRegisteredClaimNames.Iat, nowEpoch.ToString(), ClaimValueTypes.Integer64),

--- a/PlanWriter.Infrastructure/ReadModels/Auth/UserAuthReadRepository.cs
+++ b/PlanWriter.Infrastructure/ReadModels/Auth/UserAuthReadRepository.cs
@@ -16,7 +16,11 @@ public class UserAuthReadRepository(IDbExecutor db) : IUserAuthReadRepository
             Email,
             PasswordHash,
             IsAdmin,
-            MustChangePassword
+            MustChangePassword,
+            AdminMfaEnabled,
+            AdminMfaSecret,
+            AdminMfaPendingSecret,
+            AdminMfaPendingGeneratedAtUtc
         FROM Users
         WHERE Email = @Email;
     ";

--- a/PlanWriter.Infrastructure/Repositories/Auth/AdminMfaRepository.cs
+++ b/PlanWriter.Infrastructure/Repositories/Auth/AdminMfaRepository.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PlanWriter.Domain.Interfaces.Repositories.Auth;
+using PlanWriter.Infrastructure.Data;
+
+namespace PlanWriter.Infrastructure.Repositories.Auth;
+
+public sealed class AdminMfaRepository(IDbExecutor db) : IAdminMfaRepository
+{
+    public Task SetPendingSecretAsync(Guid userId, string pendingSecret, DateTime generatedAtUtc, CancellationToken ct)
+    {
+        const string sql = @"
+            UPDATE Users
+            SET
+                AdminMfaPendingSecret = @PendingSecret,
+                AdminMfaPendingGeneratedAtUtc = @GeneratedAtUtc
+            WHERE Id = @UserId
+              AND IsAdmin = 1;
+        ";
+
+        return db.ExecuteAsync(sql, new
+        {
+            UserId = userId,
+            PendingSecret = pendingSecret,
+            GeneratedAtUtc = generatedAtUtc
+        }, ct);
+    }
+
+    public Task EnableAsync(Guid userId, string activeSecret, CancellationToken ct)
+    {
+        const string sql = @"
+            UPDATE Users
+            SET
+                AdminMfaEnabled = 1,
+                AdminMfaSecret = @ActiveSecret,
+                AdminMfaPendingSecret = NULL,
+                AdminMfaPendingGeneratedAtUtc = NULL
+            WHERE Id = @UserId
+              AND IsAdmin = 1;
+        ";
+
+        return db.ExecuteAsync(sql, new
+        {
+            UserId = userId,
+            ActiveSecret = activeSecret
+        }, ct);
+    }
+
+    public async Task ReplaceBackupCodesAsync(Guid userId, IReadOnlyCollection<string> codeHashes, CancellationToken ct)
+    {
+        const string deleteSql = @"
+            DELETE FROM AdminMfaBackupCodes
+            WHERE UserId = @UserId;
+        ";
+
+        await db.ExecuteAsync(deleteSql, new { UserId = userId }, ct);
+
+        if (codeHashes.Count == 0)
+        {
+            return;
+        }
+
+        const string insertSql = @"
+            INSERT INTO AdminMfaBackupCodes
+            (
+                Id,
+                UserId,
+                CodeHash,
+                IsUsed,
+                CreatedAtUtc,
+                UsedAtUtc
+            )
+            VALUES
+            (
+                @Id,
+                @UserId,
+                @CodeHash,
+                0,
+                SYSUTCDATETIME(),
+                NULL
+            );
+        ";
+
+        var rows = codeHashes.Select(codeHash => new
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            CodeHash = codeHash
+        }).ToArray();
+
+        await db.ExecuteAsync(insertSql, rows, ct);
+    }
+
+    public async Task<bool> ConsumeBackupCodeAsync(Guid userId, string codeHash, DateTime usedAtUtc, CancellationToken ct)
+    {
+        const string sql = @"
+            UPDATE TOP (1) AdminMfaBackupCodes
+            SET
+                IsUsed = 1,
+                UsedAtUtc = @UsedAtUtc
+            WHERE UserId = @UserId
+              AND CodeHash = @CodeHash
+              AND IsUsed = 0;
+        ";
+
+        var affected = await db.ExecuteAsync(sql, new
+        {
+            UserId = userId,
+            CodeHash = codeHash,
+            UsedAtUtc = usedAtUtc
+        }, ct);
+
+        return affected == 1;
+    }
+}

--- a/PlanWriter.Infrastructure/Repositories/Auth/Register/UserRegistrationRepository.cs
+++ b/PlanWriter.Infrastructure/Repositories/Auth/Register/UserRegistrationRepository.cs
@@ -24,7 +24,11 @@ public class UserRegistrationRepository(IDbExecutor db) : IUserRegistrationRepos
                 MustChangePassword,
                 IsProfilePublic,
                 Slug,
-                DisplayName
+                DisplayName,
+                AdminMfaEnabled,
+                AdminMfaSecret,
+                AdminMfaPendingSecret,
+                AdminMfaPendingGeneratedAtUtc
             )
             VALUES
             (
@@ -38,7 +42,11 @@ public class UserRegistrationRepository(IDbExecutor db) : IUserRegistrationRepos
                 @MustChangePassword,
                 @IsProfilePublic,
                 @Slug,
-                @DisplayName
+                @DisplayName,
+                @AdminMfaEnabled,
+                @AdminMfaSecret,
+                @AdminMfaPendingSecret,
+                @AdminMfaPendingGeneratedAtUtc
             );
         ";
 
@@ -56,7 +64,11 @@ public class UserRegistrationRepository(IDbExecutor db) : IUserRegistrationRepos
                 user.MustChangePassword,
                 user.IsProfilePublic,
                 user.Slug,
-                user.DisplayName
+                user.DisplayName,
+                user.AdminMfaEnabled,
+                user.AdminMfaSecret,
+                user.AdminMfaPendingSecret,
+                user.AdminMfaPendingGeneratedAtUtc
             },
             ct
         );

--- a/PlanWriter.Infrastructure/Repositories/UserRepository.cs
+++ b/PlanWriter.Infrastructure/Repositories/UserRepository.cs
@@ -25,7 +25,11 @@ public sealed class UserRepository(IDbExecutor db) : IUserRepository
                 Slug,
                 DisplayName,
                 IsAdmin,
-                MustChangePassword
+                MustChangePassword,
+                AdminMfaEnabled,
+                AdminMfaSecret,
+                AdminMfaPendingSecret,
+                AdminMfaPendingGeneratedAtUtc
             )
             VALUES
             (
@@ -41,7 +45,11 @@ public sealed class UserRepository(IDbExecutor db) : IUserRepository
                 @Slug,
                 @DisplayName,
                 @IsAdmin,
-                @MustChangePassword
+                @MustChangePassword,
+                @AdminMfaEnabled,
+                @AdminMfaSecret,
+                @AdminMfaPendingSecret,
+                @AdminMfaPendingGeneratedAtUtc
             );
         ";
 
@@ -64,7 +72,11 @@ public sealed class UserRepository(IDbExecutor db) : IUserRepository
                 Slug = @Slug,
                 DisplayName = @DisplayName,
                 IsAdmin = @IsAdmin,
-                MustChangePassword = @MustChangePassword
+                MustChangePassword = @MustChangePassword,
+                AdminMfaEnabled = @AdminMfaEnabled,
+                AdminMfaSecret = @AdminMfaSecret,
+                AdminMfaPendingSecret = @AdminMfaPendingSecret,
+                AdminMfaPendingGeneratedAtUtc = @AdminMfaPendingGeneratedAtUtc
             WHERE Id = @Id;
         ";
 

--- a/PlanWriter.Tests/API/Integration/AdminMfaIntegrationTests.cs
+++ b/PlanWriter.Tests/API/Integration/AdminMfaIntegrationTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using PlanWriter.Application.DTO;
+using PlanWriter.Application.Security;
+using PlanWriter.Domain.Entities;
+using Xunit;
+
+namespace PlanWriter.Tests.API.Integration;
+
+[Collection(AuthApiTestCollection.Name)]
+public sealed class AdminMfaIntegrationTests(AuthApiWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task AdminArea_ShouldReturnForbidden_WhenAdminMfaClaimIsFalse()
+    {
+        factory.Store.Reset();
+        factory.AuditStore.Reset();
+
+        using var client = CreateClient(
+            Guid.NewGuid(),
+            isAdmin: true,
+            adminMfaVerified: false);
+
+        var response = await client.GetAsync("/api/admin/security/auth-audits");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AdminArea_ShouldReturnOk_WhenAdminMfaClaimIsTrue()
+    {
+        factory.Store.Reset();
+        factory.AuditStore.Reset();
+
+        using var client = CreateClient(
+            Guid.NewGuid(),
+            isAdmin: true,
+            adminMfaVerified: true);
+
+        var response = await client.GetAsync("/api/admin/security/auth-audits");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Login_ShouldRequireMfa_WhenAdminMfaIsEnabled()
+    {
+        factory.Store.Reset();
+        factory.AuditStore.Reset();
+
+        var admin = SeedAdminWithMfa("admin-mfa@test.com", "StrongAdmin#2026", out var secret);
+        using var client = CreateClient();
+
+        var noMfaResponse = await client.PostAsJsonAsync("/api/auth/login", new LoginUserDto
+        {
+            Email = admin.Email,
+            Password = "StrongAdmin#2026"
+        });
+        noMfaResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var validCode = AdminMfaSecurity.GenerateCurrentTotpCode(secret, DateTime.UtcNow);
+        var withMfaResponse = await client.PostAsJsonAsync("/api/auth/login", new LoginUserDto
+        {
+            Email = admin.Email,
+            Password = "StrongAdmin#2026",
+            MfaCode = validCode
+        });
+
+        withMfaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Login_ShouldAcceptBackupCodeOnlyOnce_WhenAdminMfaIsEnabled()
+    {
+        factory.Store.Reset();
+        factory.AuditStore.Reset();
+
+        var admin = SeedAdminWithMfa("admin-backup@test.com", "StrongAdmin#2026", out _);
+        var backupCode = "ABCD-EFGH";
+        var backupHash = AdminMfaSecurity.HashBackupCode(backupCode);
+        await factory.Store.ReplaceBackupCodesAsync(admin.Id, [backupHash], CancellationToken.None);
+
+        using var client = CreateClient();
+
+        var first = await client.PostAsJsonAsync("/api/auth/login", new LoginUserDto
+        {
+            Email = admin.Email,
+            Password = "StrongAdmin#2026",
+            BackupCode = backupCode
+        });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var second = await client.PostAsJsonAsync("/api/auth/login", new LoginUserDto
+        {
+            Email = admin.Email,
+            Password = "StrongAdmin#2026",
+            BackupCode = backupCode
+        });
+        second.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private User SeedAdminWithMfa(string email, string password, out string secret)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            FirstName = "Admin",
+            LastName = "System",
+            DateOfBirth = new DateTime(1990, 1, 1)
+        };
+        user.MakeAdmin();
+
+        var hasher = new PasswordHasher<User>();
+        user.ChangePassword(hasher.HashPassword(user, password));
+
+        secret = AdminMfaSecurity.GenerateSecretKey();
+        user.EnableAdminMfa(secret);
+        factory.Store.Seed(user);
+        return user;
+    }
+
+    private HttpClient CreateClient(
+        Guid? authenticatedUserId = null,
+        bool isAdmin = false,
+        bool adminMfaVerified = false)
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        if (!authenticatedUserId.HasValue)
+        {
+            return client;
+        }
+
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, authenticatedUserId.Value.ToString());
+        client.DefaultRequestHeaders.Add(TestAuthHandler.IsAdminHeader, isAdmin.ToString().ToLowerInvariant());
+        client.DefaultRequestHeaders.Add(TestAuthHandler.AdminMfaVerifiedHeader, adminMfaVerified.ToString().ToLowerInvariant());
+        return client;
+    }
+}

--- a/PlanWriter.Tests/API/Integration/AuthApiWebApplicationFactory.cs
+++ b/PlanWriter.Tests/API/Integration/AuthApiWebApplicationFactory.cs
@@ -30,6 +30,7 @@ public sealed class AuthApiWebApplicationFactory : WebApplicationFactory<Program
             services.RemoveAll<IAuthAuditReadRepository>();
             services.RemoveAll<IAuthAuditRepository>();
             services.RemoveAll<IRefreshTokenRepository>();
+            services.RemoveAll<IAdminMfaRepository>();
             services.RemoveAll<IJwtTokenGenerator>();
 
             services.AddSingleton<InMemoryAuthRepository>();
@@ -39,6 +40,7 @@ public sealed class AuthApiWebApplicationFactory : WebApplicationFactory<Program
             services.AddSingleton<IUserRegistrationRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
             services.AddSingleton<IUserPasswordRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
             services.AddSingleton<IUserAuthReadRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IAdminMfaRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
 
             services.AddSingleton<InMemoryRefreshTokenRepository>();
             services.AddSingleton<IRefreshTokenRepository>(sp => sp.GetRequiredService<InMemoryRefreshTokenRepository>());

--- a/PlanWriter.Tests/API/Integration/FakeJwtTokenGenerator.cs
+++ b/PlanWriter.Tests/API/Integration/FakeJwtTokenGenerator.cs
@@ -5,8 +5,8 @@ namespace PlanWriter.Tests.API.Integration;
 
 public sealed class FakeJwtTokenGenerator : IJwtTokenGenerator
 {
-    public string Generate(User user)
+    public string Generate(User user, bool adminMfaVerified = false)
     {
-        return $"fake-jwt-{user.Id}";
+        return $"fake-jwt-{user.Id}-{adminMfaVerified}";
     }
 }

--- a/PlanWriter.Tests/Admin/Commands/ChangePasswordCommandHandlerTests.cs
+++ b/PlanWriter.Tests/Admin/Commands/ChangePasswordCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class ChangePasswordCommandHandlerTests
             .ReturnsAsync(2);
 
         _tokenGeneratorMock
-            .Setup(t => t.Generate(user))
+            .Setup(t => t.Generate(user, It.IsAny<bool>()))
             .Returns(token);
 
         var handler = CreateHandler();
@@ -79,7 +79,7 @@ public class ChangePasswordCommandHandlerTests
         );
 
         _tokenGeneratorMock.Verify(
-            t => t.Generate(user),
+            t => t.Generate(user, It.IsAny<bool>()),
             Times.Once
         );
 
@@ -153,7 +153,7 @@ public class ChangePasswordCommandHandlerTests
             .ReturnsAsync(1);
 
         _tokenGeneratorMock
-            .Setup(t => t.Generate(It.Is<User>(u => u.IsAdmin && !u.MustChangePassword)))
+            .Setup(t => t.Generate(It.Is<User>(u => u.IsAdmin && !u.MustChangePassword), It.IsAny<bool>()))
             .Returns(token);
 
         var handler = CreateHandler();
@@ -167,7 +167,7 @@ public class ChangePasswordCommandHandlerTests
         user.MustChangePassword.Should().BeFalse();
 
         _tokenGeneratorMock.Verify(
-            t => t.Generate(It.Is<User>(u => u.IsAdmin && !u.MustChangePassword)),
+            t => t.Generate(It.Is<User>(u => u.IsAdmin && !u.MustChangePassword), It.IsAny<bool>()),
             Times.Once
         );
 

--- a/PlanWriter.Tests/Auth/Commands/RefreshSessionCommandHandlerTests.cs
+++ b/PlanWriter.Tests/Auth/Commands/RefreshSessionCommandHandlerTests.cs
@@ -80,7 +80,7 @@ public class RefreshSessionCommandHandlerTests
             .ReturnsAsync(true);
 
         _jwtTokenGenerator
-            .Setup(g => g.Generate(user))
+            .Setup(g => g.Generate(user, It.IsAny<bool>()))
             .Returns("access-token");
 
         var handler = CreateHandler();

--- a/PlanWriter.Tests/Infrastructure/Auth/JwtTokenGeneratorTests.cs
+++ b/PlanWriter.Tests/Infrastructure/Auth/JwtTokenGeneratorTests.cs
@@ -35,7 +35,7 @@ public class JwtTokenGeneratorTests
         user.MakeAdmin();
         user.ChangePassword("hash");
 
-        var token = sut.Generate(user);
+        var token = sut.Generate(user, adminMfaVerified: true);
 
         var parsed = new JwtSecurityTokenHandler().ReadJwtToken(token);
 
@@ -43,6 +43,7 @@ public class JwtTokenGeneratorTests
         parsed.Claims.Select(c => c.Value).Should().Contain("user@test.com");
         parsed.Claims.Select(c => c.Value).Should().Contain("Alice");
         parsed.Claims.First(c => c.Type == "isAdmin").Value.Should().Be("true");
+        parsed.Claims.First(c => c.Type == "adminMfaVerified").Value.Should().Be("true");
         parsed.Claims.First(c => c.Type == "mustChangePassword").Value.Should().Be("false");
         parsed.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Jti);
         parsed.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Iat);
@@ -69,7 +70,7 @@ public class JwtTokenGeneratorTests
                 RefreshTokenDays = 7
             }));
 
-        var act = () => sut.Generate(new User { Id = Guid.NewGuid(), Email = "user@test.com", FirstName = "Alice" });
+        var act = () => sut.Generate(new User { Id = Guid.NewGuid(), Email = "user@test.com", FirstName = "Alice" }, adminMfaVerified: false);
 
         act.Should().Throw<ArgumentException>();
     }


### PR DESCRIPTION
Resumo: MFA obrigatório para admins com enrollment TOTP, backup codes e validação em login/admin area.\n\nImplementado:\n- Estado MFA admin no usuário\n- Repositório e persistência de backup codes\n- Endpoints de enrollment e confirmação\n- Login admin exige TOTP ou backup code\n- Backup code de uso único\n- Claim adminMfaVerified no JWT\n- Bloqueio de acesso admin sem MFA verificado\n- Script SQL com campos/tabela de MFA\n- Testes unitários e integração\n\nValidação: dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --nologo --no-restore (458 passando).\n\nCloses #57