### PR TITLE
ci: exigir PR de release para entrar na main

### DIFF
--- a/.github/workflows/release-branch-gate.yml
+++ b/.github/workflows/release-branch-gate.yml
@@ -1,0 +1,20 @@
+name: Release Branch Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release-branch-gate:
+    name: Release Branch Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch pattern
+        run: |
+          echo "Base branch: ${{ github.base_ref }}"
+          echo "Head branch: ${{ github.head_ref }}"
+          if [[ "${{ github.head_ref }}" != release/* ]]; then
+            echo "PRs targeting main must come from a release/* branch." >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adiciona uma workflow (Release Branch Gate) que falha PRs para a main cuja branch de origem nao siga o padrao `release/*`.

Objetivo
- impedir merge na main vindo de branches nao-release
- manter o bloqueio de push direto (ja coberto pelo ruleset atual)

Depois do merge
- adicionar esse check como required status check no ruleset da main.