### PR TITLE
feat(winner-flow): API unificada de status de participante no evento

### DIFF
--- a/PlanWriter.API/Controllers/EventsController.cs
+++ b/PlanWriter.API/Controllers/EventsController.cs
@@ -44,6 +44,15 @@ public class EventsController(IUserService userService, IMediator mediator) : Co
         var response = await mediator.Send(new GetEventProgressQuery(eventId, projectId));
         return Ok(response);
     }
+
+    [Authorize]
+    [HttpGet("{eventId:guid}/projects/{projectId:guid}/participant-status")]
+    public async Task<ActionResult<EventParticipantStatusDto>> GetParticipantStatus(Guid eventId, Guid projectId)
+    {
+        var userId = userService.GetUserId(User);
+        var response = await mediator.Send(new GetEventParticipantStatusQuery(userId, eventId, projectId));
+        return Ok(response);
+    }
     
     [Authorize]
     [HttpPost("finalize")]

--- a/PlanWriter.Application/Events/Dtos/Queries/GetEventParticipantStatusQuery.cs
+++ b/PlanWriter.Application/Events/Dtos/Queries/GetEventParticipantStatusQuery.cs
@@ -1,0 +1,8 @@
+using System;
+using MediatR;
+using PlanWriter.Domain.Dtos.Events;
+
+namespace PlanWriter.Application.Events.Dtos.Queries;
+
+public sealed record GetEventParticipantStatusQuery(Guid UserId, Guid EventId, Guid ProjectId)
+    : IRequest<EventParticipantStatusDto>;

--- a/PlanWriter.Application/Events/Queries/GetEventParticipantStatusQueryHandler.cs
+++ b/PlanWriter.Application/Events/Queries/GetEventParticipantStatusQueryHandler.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PlanWriter.Application.Common.Events;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Common.WinnerEligibility;
+using PlanWriter.Application.EventValidation;
+using PlanWriter.Application.Events.Dtos.Queries;
+using PlanWriter.Domain.Dtos.Events;
+using PlanWriter.Domain.Events;
+using PlanWriter.Domain.Interfaces.ReadModels.Events;
+using PlanWriter.Domain.Interfaces.ReadModels.ProjectEvents;
+using PlanWriter.Domain.Interfaces.ReadModels.Projects;
+
+namespace PlanWriter.Application.Events.Queries;
+
+public sealed class GetEventParticipantStatusQueryHandler(
+    ILogger<GetEventParticipantStatusQueryHandler> logger,
+    IEventReadRepository eventReadRepository,
+    IProjectReadRepository projectReadRepository,
+    IProjectEventsReadRepository projectEventsReadRepository,
+    IProjectProgressReadRepository projectProgressReadRepository,
+    IEventProgressCalculator eventProgressCalculator,
+    IWinnerEligibilityService winnerEligibilityService)
+    : IRequestHandler<GetEventParticipantStatusQuery, EventParticipantStatusDto>
+{
+    private const string EventStatusScheduled = "scheduled";
+    private const string EventStatusActive = "active";
+    private const string EventStatusClosed = "closed";
+    private const string EventStatusDisabled = "disabled";
+
+    public async Task<EventParticipantStatusDto> Handle(GetEventParticipantStatusQuery request, CancellationToken cancellationToken)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        var eventEntity = await eventReadRepository.GetEventByIdAsync(request.EventId, cancellationToken)
+                          ?? throw new NotFoundException("Evento não encontrado.");
+
+        var project = await projectReadRepository.GetUserProjectByIdAsync(request.ProjectId, request.UserId, cancellationToken)
+                      ?? throw new NotFoundException("Projeto não encontrado.");
+
+        var projectEvent = await projectEventsReadRepository.GetByProjectAndEventWithEventAsync(
+                               request.ProjectId,
+                               request.EventId,
+                               cancellationToken)
+                           ?? throw new NotFoundException("Projeto não está inscrito neste evento.");
+
+        var effectiveEventStatus = ResolveEffectiveEventStatus(
+            nowUtc,
+            eventEntity.IsActive,
+            eventEntity.StartsAtUtc,
+            eventEntity.EndsAtUtc);
+
+        var totalWordsInWindow = await GetTotalWordsInEventWindowAsync(
+            request.ProjectId,
+            request.UserId,
+            eventEntity,
+            cancellationToken);
+
+        var effectiveTotalWords = ResolveEffectiveTotalWords(totalWordsInWindow, projectEvent, effectiveEventStatus);
+        var progressMetrics = eventProgressCalculator.Calculate(
+            projectEvent.TargetWords,
+            eventEntity.DefaultTargetWords,
+            effectiveTotalWords);
+
+        var (validationWindowStartsAtUtc, validationWindowEndsAtUtc) = ValidationPolicyHelper.ResolveValidationWindow(
+            eventEntity.StartsAtUtc,
+            eventEntity.EndsAtUtc,
+            eventEntity.ValidationWindowStartsAtUtc,
+            eventEntity.ValidationWindowEndsAtUtc);
+
+        var isValidationWindowOpen = nowUtc >= validationWindowStartsAtUtc && nowUtc <= validationWindowEndsAtUtc;
+        var isValidated = projectEvent.ValidatedAtUtc.HasValue;
+
+        var eligibility = winnerEligibilityService.EvaluateForGoodies(
+            nowUtc,
+            eventEntity.EndsAtUtc,
+            progressMetrics.TargetWords,
+            progressMetrics.TotalWords,
+            isValidated,
+            projectEvent.Won);
+
+        var validationBlockReason = ResolveValidationBlockReason(
+            isValidated,
+            isValidationWindowOpen,
+            progressMetrics.TotalWords,
+            progressMetrics.TargetWords);
+
+        var canValidate = validationBlockReason is null && eligibility.CanValidate;
+        var allowedSources = ValidationPolicyHelper.ParseAllowedSources(eventEntity.AllowedValidationSources);
+
+        logger.LogInformation(
+            "Unified participant status loaded for Event {EventId}, Project {ProjectId}, User {UserId}. EventStatus={EventStatus} EligibilityStatus={EligibilityStatus} CanValidate={CanValidate}",
+            request.EventId,
+            request.ProjectId,
+            request.UserId,
+            effectiveEventStatus,
+            eligibility.Status,
+            canValidate);
+
+        return new EventParticipantStatusDto
+        {
+            EventId = eventEntity.Id,
+            ProjectId = request.ProjectId,
+            EventName = eventEntity.Name,
+            ProjectTitle = project.Title ?? "Projeto",
+            EventStatus = effectiveEventStatus,
+            IsEventActive = string.Equals(effectiveEventStatus, EventStatusActive, StringComparison.OrdinalIgnoreCase),
+            IsEventClosed = IsClosedLikeStatus(effectiveEventStatus),
+            EventStartsAtUtc = eventEntity.StartsAtUtc,
+            EventEndsAtUtc = eventEntity.EndsAtUtc,
+            ValidationWindowStartsAtUtc = validationWindowStartsAtUtc,
+            ValidationWindowEndsAtUtc = validationWindowEndsAtUtc,
+            IsValidationWindowOpen = isValidationWindowOpen,
+            TargetWords = progressMetrics.TargetWords,
+            TotalWords = progressMetrics.TotalWords,
+            Percent = progressMetrics.Percent,
+            RemainingWords = progressMetrics.RemainingWords,
+            IsValidated = isValidated,
+            IsWinner = projectEvent.Won,
+            IsEligible = eligibility.IsEligible,
+            CanValidate = canValidate,
+            EligibilityStatus = eligibility.Status,
+            EligibilityMessage = eligibility.Message,
+            ValidationBlockReason = validationBlockReason,
+            ValidatedAtUtc = projectEvent.ValidatedAtUtc,
+            ValidatedWords = projectEvent.ValidatedWords,
+            ValidationSource = projectEvent.ValidationSource,
+            AllowedValidationSources = allowedSources
+        };
+    }
+
+    private async Task<int> GetTotalWordsInEventWindowAsync(
+        Guid projectId,
+        Guid userId,
+        EventDto eventEntity,
+        CancellationToken cancellationToken)
+    {
+        var progress = await projectProgressReadRepository.GetProgressByProjectIdAsync(projectId, userId, cancellationToken);
+        var endExclusive = eventProgressCalculator.ResolveWindowEndExclusive(eventEntity.EndsAtUtc);
+
+        return progress
+            .Where(x => x.CreatedAt >= eventEntity.StartsAtUtc && x.CreatedAt < endExclusive)
+            .Sum(x => (int?)x.WordsWritten) ?? 0;
+    }
+
+    private static int ResolveEffectiveTotalWords(int totalWordsInWindow, ProjectEvent projectEvent, string effectiveEventStatus)
+    {
+        var persistedSnapshotWords = projectEvent.ValidatedWords ?? projectEvent.FinalWordCount;
+        if (persistedSnapshotWords is null)
+            return totalWordsInWindow;
+
+        if (projectEvent.ValidatedAtUtc.HasValue && IsClosedLikeStatus(effectiveEventStatus))
+            return Math.Max(0, persistedSnapshotWords.Value);
+
+        return Math.Max(totalWordsInWindow, persistedSnapshotWords.Value);
+    }
+
+    private static string? ResolveValidationBlockReason(
+        bool isValidated,
+        bool isValidationWindowOpen,
+        int totalWords,
+        int targetWords)
+    {
+        if (isValidated)
+            return "Projeto já validado neste evento.";
+
+        if (!isValidationWindowOpen)
+            return "Validação fora da janela permitida.";
+
+        if (totalWords < targetWords)
+            return $"Faltam {targetWords - totalWords} palavras para atingir a meta.";
+
+        return null;
+    }
+
+    private static string ResolveEffectiveEventStatus(DateTime nowUtc, bool isEventActive, DateTime startsAtUtc, DateTime endsAtUtc)
+    {
+        if (!isEventActive)
+            return EventStatusDisabled;
+
+        if (nowUtc < startsAtUtc)
+            return EventStatusScheduled;
+
+        if (nowUtc > endsAtUtc)
+            return EventStatusClosed;
+
+        return EventStatusActive;
+    }
+
+    private static bool IsClosedLikeStatus(string effectiveEventStatus) =>
+        string.Equals(effectiveEventStatus, EventStatusClosed, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(effectiveEventStatus, EventStatusDisabled, StringComparison.OrdinalIgnoreCase);
+}

--- a/PlanWriter.Domain/Dtos/Events/EventParticipantStatusDto.cs
+++ b/PlanWriter.Domain/Dtos/Events/EventParticipantStatusDto.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlanWriter.Domain.Dtos.Events;
+
+public sealed class EventParticipantStatusDto
+{
+    public Guid EventId { get; set; }
+    public Guid ProjectId { get; set; }
+    public string EventName { get; set; } = string.Empty;
+    public string ProjectTitle { get; set; } = string.Empty;
+
+    public string EventStatus { get; set; } = string.Empty;
+    public bool IsEventActive { get; set; }
+    public bool IsEventClosed { get; set; }
+    public DateTime EventStartsAtUtc { get; set; }
+    public DateTime EventEndsAtUtc { get; set; }
+
+    public DateTime ValidationWindowStartsAtUtc { get; set; }
+    public DateTime ValidationWindowEndsAtUtc { get; set; }
+    public bool IsValidationWindowOpen { get; set; }
+
+    public int TargetWords { get; set; }
+    public int TotalWords { get; set; }
+    public int Percent { get; set; }
+    public int RemainingWords { get; set; }
+
+    public bool IsValidated { get; set; }
+    public bool IsWinner { get; set; }
+    public bool IsEligible { get; set; }
+    public bool CanValidate { get; set; }
+
+    public string EligibilityStatus { get; set; } = string.Empty;
+    public string EligibilityMessage { get; set; } = string.Empty;
+    public string? ValidationBlockReason { get; set; }
+
+    public DateTime? ValidatedAtUtc { get; set; }
+    public int? ValidatedWords { get; set; }
+    public string? ValidationSource { get; set; }
+
+    public IReadOnlyList<string> AllowedValidationSources { get; set; } = Array.Empty<string>();
+}

--- a/PlanWriter.Tests/Events/Queries/GetEventParticipantStatusQueryHandlerTests.cs
+++ b/PlanWriter.Tests/Events/Queries/GetEventParticipantStatusQueryHandlerTests.cs
@@ -1,0 +1,265 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using PlanWriter.Application.Common.Events;
+using PlanWriter.Application.Common.Exceptions;
+using PlanWriter.Application.Common.WinnerEligibility;
+using PlanWriter.Application.Events.Dtos.Queries;
+using PlanWriter.Application.Events.Queries;
+using PlanWriter.Domain.Dtos.Events;
+using PlanWriter.Domain.Entities;
+using PlanWriter.Domain.Events;
+using PlanWriter.Domain.Interfaces.ReadModels.Events;
+using PlanWriter.Domain.Interfaces.ReadModels.ProjectEvents;
+using PlanWriter.Domain.Interfaces.ReadModels.Projects;
+using Xunit;
+
+namespace PlanWriter.Tests.Events.Queries;
+
+public class GetEventParticipantStatusQueryHandlerTests
+{
+    private readonly Mock<ILogger<GetEventParticipantStatusQueryHandler>> _loggerMock = new();
+    private readonly Mock<IEventReadRepository> _eventReadRepositoryMock = new();
+    private readonly Mock<IProjectReadRepository> _projectReadRepositoryMock = new();
+    private readonly Mock<IProjectEventsReadRepository> _projectEventsReadRepositoryMock = new();
+    private readonly Mock<IProjectProgressReadRepository> _projectProgressReadRepositoryMock = new();
+    private readonly IEventProgressCalculator _eventProgressCalculator = new EventProgressCalculator();
+    private readonly IWinnerEligibilityService _winnerEligibilityService = new WinnerEligibilityService();
+
+    [Fact]
+    public async Task Handle_ShouldReturnReadyToValidate_WhenTargetReachedWithinValidationWindow()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                eventId,
+                "Evento de Fevereiro",
+                "evento-fev",
+                "Nanowrimo",
+                now.AddDays(-10),
+                now.AddDays(10),
+                50000,
+                true,
+                now.AddDays(-1),
+                now.AddDays(1),
+                "current,paste"));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project { Id = projectId, Title = "Meu Romance" });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(projectId, eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProjectEvent
+            {
+                Id = Guid.NewGuid(),
+                ProjectId = projectId,
+                EventId = eventId,
+                TargetWords = 50000,
+                Won = false,
+                ValidatedAtUtc = null
+            });
+
+        _projectProgressReadRepositoryMock
+            .Setup(x => x.GetProgressByProjectIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ProjectProgress>
+            {
+                new() { ProjectId = projectId, WordsWritten = 25000, CreatedAt = now.AddDays(-2) },
+                new() { ProjectId = projectId, WordsWritten = 25000, CreatedAt = now.AddHours(-2) }
+            });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetEventParticipantStatusQuery(userId, eventId, projectId), CancellationToken.None);
+
+        // Assert
+        result.EventStatus.Should().Be("active");
+        result.IsEventActive.Should().BeTrue();
+        result.IsValidationWindowOpen.Should().BeTrue();
+        result.TotalWords.Should().Be(50000);
+        result.TargetWords.Should().Be(50000);
+        result.Percent.Should().Be(100);
+        result.IsEligible.Should().BeFalse();
+        result.CanValidate.Should().BeTrue();
+        result.ValidationBlockReason.Should().BeNull();
+        result.EligibilityStatus.Should().Be("pending_validation");
+        result.AllowedValidationSources.Should().BeEquivalentTo(new[] { "current", "paste" });
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUsePersistedSnapshot_WhenValidatedAndEventClosed()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                eventId,
+                "Evento Encerrado",
+                "evento-encerrado",
+                "Nanowrimo",
+                now.AddDays(-30),
+                now.AddDays(-5),
+                1000,
+                true));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project { Id = projectId, Title = "Projeto Vencedor" });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(projectId, eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProjectEvent
+            {
+                Id = Guid.NewGuid(),
+                ProjectId = projectId,
+                EventId = eventId,
+                TargetWords = 1000,
+                Won = true,
+                ValidatedAtUtc = now.AddDays(-4),
+                ValidatedWords = 1200,
+                ValidationSource = "manual"
+            });
+
+        _projectProgressReadRepositoryMock
+            .Setup(x => x.GetProgressByProjectIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ProjectProgress>
+            {
+                new() { ProjectId = projectId, WordsWritten = 100, CreatedAt = now.AddDays(-10) }
+            });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetEventParticipantStatusQuery(userId, eventId, projectId), CancellationToken.None);
+
+        // Assert
+        result.EventStatus.Should().Be("closed");
+        result.IsEventClosed.Should().BeTrue();
+        result.TotalWords.Should().Be(1200); // snapshot final prevalece após encerramento
+        result.Percent.Should().Be(120);
+        result.IsValidated.Should().BeTrue();
+        result.IsWinner.Should().BeTrue();
+        result.IsEligible.Should().BeTrue();
+        result.CanValidate.Should().BeFalse();
+        result.ValidationBlockReason.Should().Be("Projeto já validado neste evento.");
+        result.EligibilityStatus.Should().Be("eligible");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldBlockValidation_WhenWindowIsClosed()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                eventId,
+                "Evento",
+                "evento",
+                "Nanowrimo",
+                now.AddDays(-10),
+                now.AddDays(10),
+                500,
+                true,
+                now.AddDays(-5),
+                now.AddDays(-1),
+                "current,paste,manual"));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project { Id = projectId, Title = "Projeto X" });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(projectId, eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProjectEvent
+            {
+                Id = Guid.NewGuid(),
+                ProjectId = projectId,
+                EventId = eventId,
+                TargetWords = 500,
+                Won = false
+            });
+
+        _projectProgressReadRepositoryMock
+            .Setup(x => x.GetProgressByProjectIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ProjectProgress>
+            {
+                new() { ProjectId = projectId, WordsWritten = 600, CreatedAt = now.AddDays(-2) }
+            });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetEventParticipantStatusQuery(userId, eventId, projectId), CancellationToken.None);
+
+        // Assert
+        result.TotalWords.Should().Be(600);
+        result.EligibilityStatus.Should().Be("pending_validation");
+        result.IsValidationWindowOpen.Should().BeFalse();
+        result.CanValidate.Should().BeFalse();
+        result.ValidationBlockReason.Should().Be("Validação fora da janela permitida.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrowNotFound_WhenProjectIsNotParticipant()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        _eventReadRepositoryMock
+            .Setup(x => x.GetEventByIdAsync(eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EventDto(
+                eventId,
+                "Evento",
+                "evento",
+                "Nanowrimo",
+                DateTime.UtcNow.AddDays(-1),
+                DateTime.UtcNow.AddDays(1),
+                50000,
+                true));
+
+        _projectReadRepositoryMock
+            .Setup(x => x.GetUserProjectByIdAsync(projectId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Project { Id = projectId, Title = "Projeto X" });
+
+        _projectEventsReadRepositoryMock
+            .Setup(x => x.GetByProjectAndEventWithEventAsync(projectId, eventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProjectEvent?)null);
+
+        var handler = CreateHandler();
+        var act = async () => await handler.Handle(new GetEventParticipantStatusQuery(userId, eventId, projectId), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>().WithMessage("Projeto não está inscrito neste evento.");
+    }
+
+    private GetEventParticipantStatusQueryHandler CreateHandler()
+    {
+        return new GetEventParticipantStatusQueryHandler(
+            _loggerMock.Object,
+            _eventReadRepositoryMock.Object,
+            _projectReadRepositoryMock.Object,
+            _projectEventsReadRepositoryMock.Object,
+            _projectProgressReadRepositoryMock.Object,
+            _eventProgressCalculator,
+            _winnerEligibilityService);
+    }
+}


### PR DESCRIPTION
## Resumo
Implementa a API unificada de status do participante para Winner Flow (#80), centralizando status do evento, janela de validação, progresso/meta e elegibilidade em um único endpoint.

## O que foi adicionado
- `GET /api/events/{eventId}/projects/{projectId}/participant-status`
- DTO unificado `EventParticipantStatusDto`
- Query + Handler `GetEventParticipantStatusQuery`

## Regras cobertas
- Status efetivo do evento (`scheduled|active|closed|disabled`)
- Janela de validação aberta/fechada
- Progresso/meta (`target`, `total`, `%`, `remaining`)
- Flags de elegibilidade (`isEligible`, `canValidate`, `isValidated`, `isWinner`)
- Razões de bloqueio (`fora da janela`, `meta não atingida`, `já validado`)

## Testes
- `GetEventParticipantStatusQueryHandlerTests` (4 cenários)
- Execução local: `dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --filter FullyQualifiedName~GetEventParticipantStatusQueryHandlerTests`

Closes #80
