### PR TITLE
feat(health): add api readiness endpoint

### DIFF
--- a/PlanWriter.API/Health/HealthCheckResponseWriter.cs
+++ b/PlanWriter.API/Health/HealthCheckResponseWriter.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace PlanWriter.API.Health;
+
+public static class HealthCheckResponseWriter
+{
+    public static async Task WriteJsonResponse(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var payload = new
+        {
+            status = report.Status.ToString(),
+            totalDurationMs = Math.Round(report.TotalDuration.TotalMilliseconds, 2),
+            timestampUtc = DateTime.UtcNow,
+            checks = report.Entries.ToDictionary(
+                entry => entry.Key,
+                entry => new
+                {
+                    status = entry.Value.Status.ToString(),
+                    description = entry.Value.Description,
+                    durationMs = Math.Round(entry.Value.Duration.TotalMilliseconds, 2),
+                    error = entry.Value.Exception?.Message,
+                    data = entry.Value.Data
+                })
+        };
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(payload));
+    }
+}

--- a/PlanWriter.API/Health/SqlServerConnectionHealthCheck.cs
+++ b/PlanWriter.API/Health/SqlServerConnectionHealthCheck.cs
@@ -1,0 +1,57 @@
+using System.Data.Common;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using PlanWriter.Infrastructure.Data;
+
+namespace PlanWriter.API.Health;
+
+public sealed class SqlServerConnectionHealthCheck(IDbConnectionFactory connectionFactory) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var connection = connectionFactory.CreateConnection();
+
+            if (connection is DbConnection dbConnection)
+            {
+                await dbConnection.OpenAsync(cancellationToken);
+            }
+            else
+            {
+                connection.Open();
+            }
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+
+            var probeResult = command.ExecuteScalar();
+            if (probeResult is null || Convert.ToInt32(probeResult) != 1)
+            {
+                return HealthCheckResult.Unhealthy(
+                    description: "Database probe returned an unexpected result.",
+                    data: new Dictionary<string, object>
+                    {
+                        ["probeResult"] = probeResult ?? "null"
+                    });
+            }
+
+            return HealthCheckResult.Healthy(
+                description: "Database connection is healthy.",
+                data: new Dictionary<string, object>
+                {
+                    ["database"] = connection.Database,
+                    ["dataSource"] = connection is DbConnection concreteConnection
+                        ? concreteConnection.DataSource
+                        : string.Empty
+                });
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                description: "Database connectivity check failed.",
+                exception: ex);
+        }
+    }
+}

--- a/PlanWriter.API/Program.cs
+++ b/PlanWriter.API/Program.cs
@@ -3,10 +3,13 @@ using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using FluentValidation;
 using FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using PlanWriter.API.Health;
 using PlanWriter.API.Common.Middleware;
 using PlanWriter.API.Middleware;
 using PlanWriter.API.Security;
@@ -167,6 +170,10 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddApplication();
 
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddHealthChecks()
+    .AddCheck<SqlServerConnectionHealthCheck>(
+        "sqlserver",
+        failureStatus: HealthStatus.Unhealthy);
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new() { Title = "PlanWriter API", Version = "v1" });
@@ -303,6 +310,16 @@ app.UseAuthentication();
 app.UseMiddleware<MustChangePasswordMiddleware>();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseAuthorization();
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
 app.MapControllers();
 app.Run();
 

--- a/PlanWriter.Tests/API/Integration/HealthApiTestCollection.cs
+++ b/PlanWriter.Tests/API/Integration/HealthApiTestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace PlanWriter.Tests.API.Integration;
+
+[CollectionDefinition(Name)]
+public sealed class HealthApiTestCollection : ICollectionFixture<HealthApiWebApplicationFactory>
+{
+    public const string Name = "Health API Integration";
+}

--- a/PlanWriter.Tests/API/Integration/HealthApiWebApplicationFactory.cs
+++ b/PlanWriter.Tests/API/Integration/HealthApiWebApplicationFactory.cs
@@ -1,0 +1,159 @@
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using PlanWriter.Domain.Interfaces.Auth;
+using PlanWriter.Domain.Interfaces.Auth.Regsitration;
+using PlanWriter.Domain.Interfaces.ReadModels.Auth;
+using PlanWriter.Domain.Interfaces.ReadModels.Users;
+using PlanWriter.Domain.Interfaces.Repositories;
+using PlanWriter.Domain.Interfaces.Repositories.Auth;
+using PlanWriter.Infrastructure.Data;
+
+namespace PlanWriter.Tests.API.Integration;
+
+public sealed class HealthApiWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IUserReadRepository>();
+            services.RemoveAll<IUserRepository>();
+            services.RemoveAll<IUserRegistrationReadRepository>();
+            services.RemoveAll<IUserRegistrationRepository>();
+            services.RemoveAll<IUserPasswordRepository>();
+            services.RemoveAll<IUserAuthReadRepository>();
+            services.RemoveAll<IAuthAuditReadRepository>();
+            services.RemoveAll<IAuthAuditRepository>();
+            services.RemoveAll<IRefreshTokenRepository>();
+            services.RemoveAll<IAdminMfaRepository>();
+            services.RemoveAll<IJwtTokenGenerator>();
+            services.RemoveAll<IDbConnectionFactory>();
+
+            services.AddSingleton<InMemoryAuthRepository>();
+            services.AddSingleton<IUserReadRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IUserRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IUserRegistrationReadRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IUserRegistrationRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IUserPasswordRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IUserAuthReadRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+            services.AddSingleton<IAdminMfaRepository>(sp => sp.GetRequiredService<InMemoryAuthRepository>());
+
+            services.AddSingleton<InMemoryRefreshTokenRepository>();
+            services.AddSingleton<IRefreshTokenRepository>(sp => sp.GetRequiredService<InMemoryRefreshTokenRepository>());
+
+            services.AddSingleton<InMemoryAuthAuditRepository>();
+            services.AddSingleton<IAuthAuditRepository>(sp => sp.GetRequiredService<InMemoryAuthAuditRepository>());
+            services.AddSingleton<IAuthAuditReadRepository>(sp => sp.GetRequiredService<InMemoryAuthAuditRepository>());
+            services.AddSingleton<IJwtTokenGenerator, FakeJwtTokenGenerator>();
+
+            services.AddSingleton<IDbConnectionFactory, HealthyDbConnectionFactory>();
+
+            services
+                .AddAuthentication(options =>
+                {
+                    options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                    options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+                })
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+        });
+    }
+
+    private sealed class HealthyDbConnectionFactory : IDbConnectionFactory
+    {
+        public IDbConnection CreateConnection() => new HealthyDbConnection();
+    }
+
+    private sealed class HealthyDbConnection : DbConnection
+    {
+        private ConnectionState _state = ConnectionState.Closed;
+
+        public override string ConnectionString { get; set; } = "Server=fake;Database=PlanWriterDb";
+        public override string Database => "PlanWriterDb";
+        public override string DataSource => "FakeSqlServer";
+        public override string ServerVersion => "1.0";
+        public override ConnectionState State => _state;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close() => _state = ConnectionState.Closed;
+
+        public override void Open() => _state = ConnectionState.Open;
+
+        public override Task OpenAsync(CancellationToken cancellationToken)
+        {
+            Open();
+            return Task.CompletedTask;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+            => throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand() => new HealthyDbCommand(this);
+    }
+
+    private sealed class HealthyDbCommand(HealthyDbConnection connection) : DbCommand
+    {
+        public override string CommandText { get; set; } = string.Empty;
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection DbConnection { get; set; } = connection;
+        protected override DbParameterCollection DbParameterCollection { get; } = new EmptyParameterCollection();
+        protected override DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        public override int ExecuteNonQuery() => 1;
+
+        public override object ExecuteScalar() => 1;
+
+        public override void Prepare()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter() => throw new NotSupportedException();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class EmptyParameterCollection : DbParameterCollection
+    {
+        public override int Count => 0;
+        public override object SyncRoot => new();
+        public override int Add(object value) => throw new NotSupportedException();
+        public override void AddRange(Array values) => throw new NotSupportedException();
+        public override void Clear()
+        {
+        }
+
+        public override bool Contains(object value) => false;
+        public override bool Contains(string value) => false;
+        public override void CopyTo(Array array, int index) => throw new NotSupportedException();
+        public override IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+        protected override DbParameter GetParameter(int index) => throw new NotSupportedException();
+        protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+        public override int IndexOf(object value) => -1;
+        public override int IndexOf(string parameterName) => -1;
+        public override void Insert(int index, object value) => throw new NotSupportedException();
+        public override void Remove(object value) => throw new NotSupportedException();
+        public override void RemoveAt(int index) => throw new NotSupportedException();
+        public override void RemoveAt(string parameterName) => throw new NotSupportedException();
+        protected override void SetParameter(int index, DbParameter value) => throw new NotSupportedException();
+        protected override void SetParameter(string parameterName, DbParameter value) => throw new NotSupportedException();
+    }
+}

--- a/PlanWriter.Tests/API/Integration/HealthEndpointIntegrationTests.cs
+++ b/PlanWriter.Tests/API/Integration/HealthEndpointIntegrationTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace PlanWriter.Tests.API.Integration;
+
+[Collection(HealthApiTestCollection.Name)]
+public sealed class HealthEndpointIntegrationTests(HealthApiWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task GetHealth_ShouldReturnHealthyJsonPayload()
+    {
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var response = await client.GetAsync("/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        payload.RootElement.GetProperty("status").GetString().Should().Be("Healthy");
+        payload.RootElement.GetProperty("checks").GetProperty("sqlserver").GetProperty("status").GetString()
+            .Should().Be("Healthy");
+    }
+}


### PR DESCRIPTION
## Summary
- add a real  endpoint backed by a SQL connectivity probe
- return structured JSON payload for readiness checks
- cover the endpoint with backend integration tests

## Validation
- dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --filter HealthEndpointIntegrationTests
- dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --no-restore