### PR TITLE
fix(health): expose readiness endpoint on api path

### DIFF
--- a/PlanWriter.API/Program.cs
+++ b/PlanWriter.API/Program.cs
@@ -310,7 +310,7 @@ app.UseAuthentication();
 app.UseMiddleware<MustChangePasswordMiddleware>();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseAuthorization();
-app.MapHealthChecks("/health", new HealthCheckOptions
+var healthCheckOptions = new HealthCheckOptions
 {
     ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse,
     ResultStatusCodes =
@@ -319,7 +319,9 @@ app.MapHealthChecks("/health", new HealthCheckOptions
         [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
         [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
     }
-});
+};
+app.MapHealthChecks("/health", healthCheckOptions);
+app.MapHealthChecks("/api/health", healthCheckOptions);
 app.MapControllers();
 app.Run();
 

--- a/PlanWriter.Tests/API/Integration/HealthEndpointIntegrationTests.cs
+++ b/PlanWriter.Tests/API/Integration/HealthEndpointIntegrationTests.cs
@@ -27,4 +27,23 @@ public sealed class HealthEndpointIntegrationTests(HealthApiWebApplicationFactor
         payload.RootElement.GetProperty("checks").GetProperty("sqlserver").GetProperty("status").GetString()
             .Should().Be("Healthy");
     }
+
+    [Fact]
+    public async Task GetApiHealth_ShouldReturnHealthyJsonPayload()
+    {
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var response = await client.GetAsync("/api/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        payload.RootElement.GetProperty("status").GetString().Should().Be("Healthy");
+        payload.RootElement.GetProperty("checks").GetProperty("sqlserver").GetProperty("status").GetString()
+            .Should().Be("Healthy");
+    }
 }


### PR DESCRIPTION
## Summary
- expose the readiness endpoint on both  and 
- keep the JSON health payload identical on both paths
- cover the proxied path with an integration test

## Validation
- dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --filter HealthEndpointIntegrationTests