### PR TITLE
fix(draft): evitar falso 409 em conflito de rascunho

### DIFF
--- a/PlanWriter.Infrastructure/Repositories/ProjectDraftRepository.cs
+++ b/PlanWriter.Infrastructure/Repositories/ProjectDraftRepository.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using Dapper;
 using PlanWriter.Domain.Dtos.Projects;
 using PlanWriter.Domain.Exceptions;
 using PlanWriter.Domain.Interfaces.Repositories;
@@ -64,29 +66,46 @@ public class ProjectDraftRepository(IDbExecutor db) : IProjectDraftRepository
             UserId = userId
         }, ct);
 
+        static DynamicParameters CreateDraftWriteParameters(
+            Guid projectId,
+            Guid userId,
+            string htmlContent,
+            DateTime updatedAtUtc,
+            DateTime? expectedUpdatedAtUtc = null)
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("ProjectId", projectId, DbType.Guid);
+            parameters.Add("UserId", userId, DbType.Guid);
+            parameters.Add("HtmlContent", htmlContent, DbType.String);
+            parameters.Add("UpdatedAtUtc", updatedAtUtc, DbType.DateTime2);
+            if (expectedUpdatedAtUtc.HasValue)
+                parameters.Add("ExpectedUpdatedAtUtc", expectedUpdatedAtUtc.Value, DbType.DateTime2);
+            return parameters;
+        }
+
         if (currentDraft is null)
         {
-            await db.ExecuteAsync(insertSql, new
-            {
-                ProjectId = projectId,
-                UserId = userId,
-                HtmlContent = htmlContent,
-                UpdatedAtUtc = updatedAtUtc
-            }, ct);
+            var insertParameters = CreateDraftWriteParameters(
+                projectId,
+                userId,
+                htmlContent,
+                updatedAtUtc);
+
+            await db.ExecuteAsync(insertSql, insertParameters, ct);
         }
         else
         {
             if (lastKnownUpdatedAtUtc.HasValue && currentDraft.UpdatedAtUtc != lastKnownUpdatedAtUtc.Value)
                 throw new ProjectDraftConflictException(currentDraft);
 
-            var affected = await db.ExecuteAsync(updateSql, new
-            {
-                ProjectId = projectId,
-                UserId = userId,
-                HtmlContent = htmlContent,
-                UpdatedAtUtc = updatedAtUtc,
-                ExpectedUpdatedAtUtc = currentDraft.UpdatedAtUtc
-            }, ct);
+            var updateParameters = CreateDraftWriteParameters(
+                projectId,
+                userId,
+                htmlContent,
+                updatedAtUtc,
+                currentDraft.UpdatedAtUtc);
+
+            var affected = await db.ExecuteAsync(updateSql, updateParameters, ct);
 
             if (affected == 0)
             {


### PR DESCRIPTION
Corrige falso conflito 409 no salvamento de rascunho rico (editor).

Causa
- comparação de `UpdatedAtUtc` no SQL com parâmetro DateTime podia perder precisão e falhar no `WHERE`

Ajuste
- `ProjectDraftRepository` agora envia parâmetros de escrita como `DbType.DateTime2` (incluindo `ExpectedUpdatedAtUtc`)

Impacto esperado
- botão "Manter minha versão" deixa de entrar em loop de conflito
- modal de conflito para de reaparecer por falso 409

Validação
- [x] `dotnet test PlanWriter.Tests/PlanWriter.Tests.csproj --filter "FullyQualifiedName~ProjectDraft"`
- [ ] merge em staging
- [ ] teste manual no editor (manter minha versão)